### PR TITLE
reset instance variables before start

### DIFF
--- a/lib/mcrain/rabbitmq.rb
+++ b/lib/mcrain/rabbitmq.rb
@@ -32,22 +32,16 @@ module Mcrain
       "guest"
     end
 
-    def client
-      require client_require
-      @client ||= RabbitMQ::HTTP::Client.new(*build_client_args)
-    end
-
-    def build_client_args
-      ["http://#{host}:#{port}", {username: username, password: password}]
-    end
-
     def client_require
       'rabbitmq/http/client'
     end
 
-    def client_script
-      client
-      "RabbitMQ::HTTP::Client.new(*#{build_client_args.inspect})"
+    def client_class
+      RabbitMQ::HTTP::Client
+    end
+
+    def client_init_args
+      ["http://#{host}:#{port}", {username: username, password: password}]
     end
 
     def wait_for_ready

--- a/lib/mcrain/redis.rb
+++ b/lib/mcrain/redis.rb
@@ -10,22 +10,16 @@ module Mcrain
     self.container_image = "redis:2.8.19"
     self.port = 6379
 
-    def client
-      require client_require
-      @client ||= ::Redis.new(build_client_options)
-    end
-
-    def build_client_options
-      {host: host, port: port}
-    end
-
     def client_require
       'redis'
     end
 
-    def client_script
-      client
-      "Redis.new(#{build_client_options.inspect})"
+    def client_class
+      ::Redis
+    end
+
+    def client_init_args
+      [{host: host, port: port}]
     end
 
     def wait_for_ready

--- a/lib/mcrain/version.rb
+++ b/lib/mcrain/version.rb
@@ -1,3 +1,3 @@
 module Mcrain
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/mcrain/rabbitmq_spec.rb
+++ b/spec/mcrain/rabbitmq_spec.rb
@@ -19,4 +19,17 @@ describe Mcrain::Rabbitmq do
     it{ uri = URI.parse(s.runtime_url);  expect(uri.scheme).to eq "rabbitmq" }
   end
 
+  context "start twice" do
+    it do
+      first = nil
+      Mcrain[:rabbitmq].start do |s|
+        first = s.client
+        expect(s.client).to eq first
+      end
+      Mcrain[:rabbitmq].start do |s|
+        expect(s.client).to_not eq first
+      end
+    end
+  end
+
 end

--- a/spec/mcrain/redis_spec.rb
+++ b/spec/mcrain/redis_spec.rb
@@ -10,4 +10,17 @@ describe Mcrain::Redis do
     end
   end
 
+  context "start twice" do
+    it do
+      first = nil
+      Mcrain[:redis].start do |s|
+        first = s.client
+        expect(s.client).to eq first
+      end
+      Mcrain[:redis].start do |s|
+        expect(s.client).to_not eq first
+      end
+    end
+  end
+
 end

--- a/spec/mcrain/riak_spec.rb
+++ b/spec/mcrain/riak_spec.rb
@@ -5,6 +5,7 @@ describe Mcrain::Riak do
   context ".start" do
     let(:data){ {"foo" => {"bar" => "baz"}} }
     it do
+      first = nil
       Mcrain[:riak].start do |s|
         c = s.client
         obj1 = c.bucket("bucket1").get_or_new("foo")
@@ -15,6 +16,11 @@ describe Mcrain::Riak do
         expect(obj2.content_type).to eq "application/json"
         expect(JSON.parse(obj2.raw_data)).to eq data
 
+        first = s.client
+        expect(s.client).to eq first
+      end
+      Mcrain[:riak].start do |s|
+        expect(s.client).to_not eq first
       end
     end
   end


### PR DESCRIPTION
- Refactor the methods to build client object
- Reset the instance variables
  - After start and stop a container, the container is stopped but the client was still alive.
  - The client must be re-created to connect to new container
## reviewers
- [ ] @nagachika 
- [x] @minimum2scp 
