### PR TITLE
don't reset on start

### DIFF
--- a/lib/mcrain/base.rb
+++ b/lib/mcrain/base.rb
@@ -17,6 +17,8 @@ module Mcrain
 
       attr_accessor :container_image, :port
     end
+
+    attr_accessor :skip_reset_after_stop
     def reset
       instance_variables.each do |var|
         instance_variable_set(var, nil)
@@ -52,7 +54,6 @@ module Mcrain
     end
 
     def start
-      reset
       clear_old_container
       run_container
       if block_given?
@@ -143,6 +144,7 @@ module Mcrain
 
     def stop
       LoggerPipe.run(logger, "docker kill #{container_name}", timeout: 10)
+      reset unless skip_reset_after_stop
     end
 
     def logger

--- a/lib/mcrain/riak.rb
+++ b/lib/mcrain/riak.rb
@@ -111,8 +111,7 @@ module Mcrain
     attr_reader :host, :cids, :pb_ports, :uris, :admin_uris
     attr_accessor :automatic_clustering, :cluster_size
 
-    def reset
-      super
+    def setup
       w = @work_dir = Mcrain::Riak.docker_riak_path
       raise "#{self.class.name}.docker_riak_path is blank. You have to set it to use the class" if w.blank?
       raise "#{w}/Makefile not found" unless File.readable?(File.join(w, "Makefile"))
@@ -126,6 +125,7 @@ module Mcrain
     end
 
     def run_container
+      setup
       logger.debug("cd #{@work_dir.inspect}")
       Dir.chdir(@work_dir) do
         # http://basho.co.jp/riak-quick-start-with-docker/
@@ -152,6 +152,7 @@ module Mcrain
       Dir.chdir(@work_dir) do
         LoggerPipe.run(logger, "#{@prepare_cmd} make stop-cluster")
       end
+      reset unless skip_reset_after_stop
     end
 
   end

--- a/lib/mcrain/version.rb
+++ b/lib/mcrain/version.rb
@@ -1,3 +1,3 @@
 module Mcrain
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/mcrain/rabbitmq_spec.rb
+++ b/spec/mcrain/rabbitmq_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'spec_helper'
 
 describe Mcrain::Rabbitmq do
@@ -29,6 +30,16 @@ describe Mcrain::Rabbitmq do
       Mcrain[:rabbitmq].start do |s|
         expect(s.client).to_not eq first
       end
+    end
+  end
+
+  context "don't reset for first start" do
+    it do
+      first_url = Mcrain[:rabbitmq].url
+      Mcrain[:rabbitmq].start do |s|
+        expect(s.url).to eq first_url
+      end
+      expect(Mcrain[:rabbitmq].url).to_not eq first_url
     end
   end
 

--- a/spec/mcrain/redis_spec.rb
+++ b/spec/mcrain/redis_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'spec_helper'
 
 describe Mcrain::Redis do
@@ -20,6 +21,24 @@ describe Mcrain::Redis do
       Mcrain[:redis].start do |s|
         expect(s.client).to_not eq first
       end
+    end
+  end
+
+  context "skip_reset_after_stop" do
+    after{ Mcrain[:redis].skip_reset_after_stop = nil }
+
+    it false do
+      Mcrain[:redis].skip_reset_after_stop = false
+      first_url = Mcrain[:redis].url
+      Mcrain[:redis].start{ }
+      expect(Mcrain[:redis].url).to_not eq first_url
+    end
+
+    it true do
+      Mcrain[:redis].skip_reset_after_stop = true
+      first_url = Mcrain[:redis].url
+      Mcrain[:redis].start{ }
+      expect(Mcrain[:redis].url).to eq first_url
     end
   end
 

--- a/spec/mcrain/riak_spec.rb
+++ b/spec/mcrain/riak_spec.rb
@@ -25,4 +25,15 @@ describe Mcrain::Riak do
     end
   end
 
+  context "don't reset for first start" do
+    it do
+      Mcrain[:riak].skip_reset_after_stop = true
+      expect(Mcrain[:riak].uris).to eq nil
+      Mcrain[:riak].start do |s|
+        expect(s.uris).to_not be_nil
+      end
+      expect(Mcrain[:riak].uris).to_not be_nil
+    end
+  end
+
 end


### PR DESCRIPTION
because specs can get container settings before it starts.

and add skip_reset_after_stop in order to get the settings after stop.
If set it true, mcrain doesn't reset the settings after container stops.
## reviewers
- [x] @nagachika 
- [x] @minimum2scp 
