### PR TITLE
work with boot2docker 1.7.0

### DIFF
--- a/lib/mcrain/boot2docker.rb
+++ b/lib/mcrain/boot2docker.rb
@@ -26,7 +26,8 @@ module Mcrain
       unless `boot2docker status`.strip == "running"
         raise "boot2docker is not running. Please `boot2docker start`"
       end
-      "%s && " % `boot2docker shellinit`.strip.split(/\n/).join(" && ")
+      exports = `boot2docker shellinit 2>/dev/null`.strip.split(/\n/)
+      exports.empty? ? '' : "%s && " % exports.join(" && ")
     end
 
     def setup_docker_options

--- a/lib/mcrain/riak.rb
+++ b/lib/mcrain/riak.rb
@@ -54,7 +54,7 @@ module Mcrain
       uri = URI.parse(ENV["DOCKER_HOST"])
       @host = (uri.scheme == "unix") ? "localhost" : uri.host
       list = Docker::Container.all
-      riak_containers = list.select{|r| r.info['Image'] == "hectcastro/riak:latest"}
+      riak_containers = list.select{|r| r.info['Image'] =~ /\Ahectcastro\/riak(\:.+)?\z/}
       @cids = riak_containers.map(&:id)
       @pb_ports = riak_containers.map do |r|
         map = r.info['Ports'].each_with_object({}){|rr,d| d[ rr['PrivatePort'] ] = rr['PublicPort']}

--- a/lib/mcrain/version.rb
+++ b/lib/mcrain/version.rb
@@ -1,3 +1,3 @@
 module Mcrain
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
- don't add exports to the command for riak  if `boot2docker shellinit` returns empty string
  - Since 1.7.0 `boot2docker shellinit` returns empty string if environment variables are already set.
    - `Your environment variables are already set correctly`
- allow image name without version for riak
## reviewers
- [x] @nagachika 
- [x] @minimum2scp 
