### PR TITLE
stop using --name option

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "spec/support/docker-riak"]
-	path = spec/support/docker-riak
-	url = git@github.com:hectcastro/docker-riak.git

--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@ It supports redis, rabbitmq and riak (stand alone node or clustering) currently.
 
 ## Prerequisite
 
-### Setup docker
+### With boot2docker
+
+- [install docker into Mac](https://docs.docker.com/installation/mac/)
+- [install docker into Windows](https://docs.docker.com/installation/windows/)
+
+
+### Without boot2docker
 
 The docker daemon must be started with tcp socket option like `-H tcp://0.0.0.0:2375`.
 Because mcrain uses [Docker Remote API](https://docs.docker.com/reference/api/docker_remote_api/).
@@ -20,9 +26,20 @@ And add tcp option to DOCKER_OPTS like this:
 DOCKER_OPTS="-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375"
 ```
 
-For more information see the following documents:
+Then restart the docker daemon.
+
+
+Set `DOCKER_HOST` environment variable for mcrain.
+```
+export DOCKER_HOST='tcp://127.0.0.1:2375'
+```
+
+The port num must be equal to the port of tcp option in DOCKER_OPTS.
+
+See the following documents for more information:
 - https://docs.docker.com/reference/commandline/daemon/
 - https://docs.docker.com/articles/networking/
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,13 @@ It supports redis, rabbitmq and riak (stand alone node or clustering) currently.
 
 ## prerequisite
 
-### docker
+### setup docker
 
-[installation](https://docs.docker.com/installation/#installation)
-
-docker must be started with tcp socket option like `-H tcp://0.0.0.0:2375`.
+The docker daemon must be started with tcp socket option like `-H tcp://0.0.0.0:2375`.
 Because mcrain uses [Docker Remote API](https://docs.docker.com/reference/api/docker_remote_api/).
 
-After installing docker, edit the configuration file `/etc/default/docker` for Debian or Ubuntu,
+After [installing docker](https://docs.docker.com/installation/#installation),
+edit the configuration file `/etc/default/docker` for Debian or Ubuntu,
 or `/etc/sysconfig/docker` for CentOS. 
 
 And add tcp option to DOCKER_OPTS like this:
@@ -21,7 +20,7 @@ And add tcp option to DOCKER_OPTS like this:
 DOCKER_OPTS="-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375"
 ```
 
-Now mcrain doesn't support HTTPS protocol, so you can't use `--tls` option for this.
+Now mcrain doesn't support HTTPS protocol yet, so you can't use `--tls` option for this.
 
 For more information see the following documents:
 - https://docs.docker.com/reference/commandline/daemon/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,27 @@ It supports redis, rabbitmq and riak (stand alone node or clustering) currently.
 
 ## prerequisite
 
-- [docker](https://docs.docker.com/installation/#installation)
+### docker
+
+[installation](https://docs.docker.com/installation/#installation)
+
+docker must be started with tcp socket option like `-H tcp://0.0.0.0:2375`.
+Because mcrain uses [Docker Remote API](https://docs.docker.com/reference/api/docker_remote_api/).
+
+After installing docker, edit the configuration file `/etc/default/docker` for Debian or Ubuntu,
+or `/etc/sysconfig/docker` for CentOS. 
+
+And add tcp option to DOCKER_OPTS like this:
+
+```
+DOCKER_OPTS="-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375"
+```
+
+Now mcrain doesn't support HTTPS protocol, so you can't use `--tls` option for this.
+
+For more information see the following documents:
+- https://docs.docker.com/reference/commandline/daemon/
+- https://docs.docker.com/articles/networking/
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Mcrain helps you to use docker container in test cases.
 It supports redis, rabbitmq and riak (stand alone node or clustering) currently.
 
-## prerequisite
+## Prerequisite
 
-### setup docker
+### Setup docker
 
 The docker daemon must be started with tcp socket option like `-H tcp://0.0.0.0:2375`.
 Because mcrain uses [Docker Remote API](https://docs.docker.com/reference/api/docker_remote_api/).
@@ -19,8 +19,6 @@ And add tcp option to DOCKER_OPTS like this:
 ```
 DOCKER_OPTS="-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375"
 ```
-
-Now mcrain doesn't support HTTPS protocol yet, so you can't use `--tls` option for this.
 
 For more information see the following documents:
 - https://docs.docker.com/reference/commandline/daemon/

--- a/exe/mcrain
+++ b/exe/mcrain
@@ -4,8 +4,8 @@
 require "mcrain"
 
 action, service, *args  = *ARGV
+verbose = ARGV.include?('-V') || ARGV.include?('--verbose') 
 if action.nil? || service.nil?
-
   $stderr.puts(<<MESSAGE)
 #{$PROGRAM_NAME} <action> <target> [n] [-v or --verbose]
   action: start or stop
@@ -41,6 +41,7 @@ begin
   end
 rescue => e
   $stderr.puts "\e[31m[#{e.class}] #{e.message}\e[0m"
+  $stderr.puts e.backtrace.join("\n  ") if verbose
   exit(1)
 else
   $stderr.puts "\e[32mOK\e[0m"

--- a/lib/mcrain.rb
+++ b/lib/mcrain.rb
@@ -77,6 +77,7 @@ module Mcrain
 
   autoload :Base, 'mcrain/base'
   autoload :Boot2docker, 'mcrain/boot2docker'
+  autoload :ContainerController, 'mcrain/container_controller'
   autoload :ClientProvider, 'mcrain/client_provider'
 
   autoload :Riak, 'mcrain/riak'

--- a/lib/mcrain.rb
+++ b/lib/mcrain.rb
@@ -77,6 +77,7 @@ module Mcrain
 
   autoload :Base, 'mcrain/base'
   autoload :Boot2docker, 'mcrain/boot2docker'
+  autoload :ClientProvider, 'mcrain/client_provider'
 
   autoload :Riak, 'mcrain/riak'
   autoload :Redis, 'mcrain/redis'

--- a/lib/mcrain/base.rb
+++ b/lib/mcrain/base.rb
@@ -13,15 +13,6 @@ module Mcrain
     include ContainerController
     include ClientProvider
 
-    class << self
-      attr_writer :server_name
-      def server_name
-        @server_name ||= self.name.split(/::/).last.underscore.to_sym
-      end
-
-      attr_accessor :container_image, :port
-    end
-
     def logger
       Mcrain.logger
     end

--- a/lib/mcrain/base.rb
+++ b/lib/mcrain/base.rb
@@ -10,6 +10,7 @@ require 'docker'
 
 module Mcrain
   class Base
+    include ClientProvider
 
     class << self
       attr_writer :server_name
@@ -117,32 +118,6 @@ module Mcrain
       raise NotImplementedError
     end
 
-    def client
-      @client ||= build_client
-    end
-
-    def build_client
-      require client_require
-      yield if block_given?
-      client_class.new(*client_init_args)
-    end
-
-    def client_require
-      raise NotImplementedError
-    end
-
-    def client_class
-      raise NotImplementedError
-    end
-
-    def client_init_args
-      raise NotImplementedError
-    end
-
-    def client_script
-      client
-      "#{client_class.name}.new(*#{client_init_args.inspect})"
-    end
 
     def teardown
       begin

--- a/lib/mcrain/base.rb
+++ b/lib/mcrain/base.rb
@@ -32,10 +32,6 @@ module Mcrain
       self.class.container_image or raise "No container_image for #{self.class.name}"
     end
 
-    def container_name
-      "test-#{self.class.server_name}"
-    end
-
     def host
       @host ||= URI.parse(ENV["DOCKER_HOST"] || "tcp://localhost").host
     end

--- a/lib/mcrain/base.rb
+++ b/lib/mcrain/base.rb
@@ -50,9 +50,7 @@ module Mcrain
 
     # ポートがLISTENされるまで待つ
     def wait_port
-      nodes.each do |node|
-        Mcrain.wait_port_opened(node.host, node.port, interval: 0.5, timeout: 30)
-      end
+      Mcrain.wait_port_opened(host, port, interval: 0.5, timeout: 30)
     end
 
     # ポートはdockerがまずLISTENしておいて、その後コンテナ内のミドルウェアが起動するので、

--- a/lib/mcrain/base.rb
+++ b/lib/mcrain/base.rb
@@ -56,7 +56,6 @@ module Mcrain
     end
 
     def start
-      # clear_old_container
       run_container
       if block_given?
         begin
@@ -69,12 +68,6 @@ module Mcrain
         wait
         return self
       end
-    end
-
-    def clear_old_container
-      LoggerPipe.run(logger, "docker rm #{container_name}", timeout: 10)
-    rescue => e
-      logger.warn("[#{e.class}] #{e.message}")
     end
 
     # @return [Docker::Container]
@@ -95,18 +88,6 @@ module Mcrain
       return container
     end
 
-    def build_docker_command
-      "docker run #{build_docker_command_options} #{container_image}"
-    end
-
-    def build_docker_command_options
-      r = "-d -p #{port}:#{self.class.port} --name #{container_name}"
-      if ext = docker_extra_options
-        r << ext
-      end
-      r
-    end
-
     def build_docker_options
       {
         'Image' => container_image,
@@ -116,10 +97,6 @@ module Mcrain
           }
         }
       }
-    end
-
-    def docker_extra_options
-      nil
     end
 
     def wait
@@ -170,8 +147,6 @@ module Mcrain
     end
 
     def stop
-      # LoggerPipe.run(logger, "docker kill #{container_name}", timeout: 10)
-
       begin
         container.stop!
       rescue => e

--- a/lib/mcrain/client_provider.rb
+++ b/lib/mcrain/client_provider.rb
@@ -1,0 +1,32 @@
+module Mcrain
+  module ClientProvider
+
+    def client
+      @client ||= build_client
+    end
+
+    def build_client
+      require client_require
+      yield if block_given?
+      client_class.new(*client_init_args)
+    end
+
+    def client_require
+      raise NotImplementedError
+    end
+
+    def client_class
+      raise NotImplementedError
+    end
+
+    def client_init_args
+      raise NotImplementedError
+    end
+
+    def client_script
+      client
+      "#{client_class.name}.new(*#{client_init_args.inspect})"
+    end
+
+  end
+end

--- a/lib/mcrain/container_controller.rb
+++ b/lib/mcrain/container_controller.rb
@@ -2,6 +2,19 @@
 module Mcrain
   module ContainerController
 
+    def self.included(klass)
+      klass.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      attr_writer :server_name
+      def server_name
+        @server_name ||= self.name.split(/::/).last.underscore.to_sym
+      end
+
+      attr_accessor :container_image, :port
+    end
+
     # @return [Docker::Container]
     def container
       unless @container

--- a/lib/mcrain/container_controller.rb
+++ b/lib/mcrain/container_controller.rb
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+module Mcrain
+  module ContainerController
+
+    # @return [Docker::Container]
+    def container
+      unless @container
+        options = build_docker_options
+        Mcrain.logger.info("#{self.class.name}#container Docker::Container.create(#{options.inspect})")
+        @container = Docker::Container.create(options)
+      end
+      @container
+    end
+
+    def container_image
+      self.class.container_image or raise "No container_image for #{self.class.name}"
+    end
+
+    def host
+      @host ||= URI.parse(ENV["DOCKER_HOST"] || "tcp://localhost").host
+    end
+
+    def find_portno
+      # 未使用のポートをシステムに割り当てさせてすぐ閉じてそれを利用する
+      tmpserv = TCPServer.new(0)
+      portno = tmpserv.local_address.ip_port
+      tmpserv.close
+      portno
+    end
+
+    def port
+      @port ||= find_portno
+    end
+
+    def url
+      @url ||= "#{self.class.server_name}://#{host}:#{port}"
+    end
+
+    def build_docker_options
+      {
+        'Image' => container_image,
+        'HostConfig' => {
+          'PortBindings' => {
+            "#{self.class.port}/tcp": [{ 'HostPort': port.to_s }]
+          }
+        }
+      }
+    end
+
+  end
+end

--- a/lib/mcrain/container_controller.rb
+++ b/lib/mcrain/container_controller.rb
@@ -54,7 +54,7 @@ module Mcrain
         'Image' => container_image,
         'HostConfig' => {
           'PortBindings' => {
-            "#{self.class.port}/tcp": [{ 'HostPort': port.to_s }]
+            "#{self.class.port}/tcp" => [{ 'HostPort' => port.to_s }]
           }
         }
       }

--- a/lib/mcrain/mysql.rb
+++ b/lib/mcrain/mysql.rb
@@ -52,9 +52,5 @@ module Mcrain
       return r
     end
 
-
-    def docker_extra_options
-      opts.compact.join(' ')
-    end
   end
 end

--- a/lib/mcrain/mysql.rb
+++ b/lib/mcrain/mysql.rb
@@ -37,16 +37,23 @@ module Mcrain
     attr_accessor :database
     attr_accessor :username, :password
 
-    def docker_extra_options
-      opts = ['']
+    def build_docker_options
+      r = super
+
       username = self.username || "root" # overwrite locally
       key_user = (username == "root") ? nil                   : "MYSQL_USER"
       key_pw   = (username == "root") ? "MYSQL_ROOT_PASSWORD" : "MYSQL_PASSWORD"
+      envs = []
+      envs << (password.blank? ? "MYSQL_ALLOW_EMPTY_PASSWORD=yes" : "#{key_pw}=#{password}")
+      envs << "#{key_user}=#{username}"  if key_user
+      envs << "MYSQL_DATABASE=#{database}" if database
+      envs << "#{File.expand_path(db_dir)}:/var/lib/mysql" if db_dir
+      r['Env'] = envs unless envs.empty?
+      return r
+    end
 
-      opts << (password.blank? ? "-e MYSQL_ALLOW_EMPTY_PASSWORD=yes" : "-e #{key_pw}=#{password}")
-      opts << (key_user ? "-e #{key_user}=#{username}" : nil)
-      opts << "-e MYSQL_DATABASE=#{database}" if database
-      opts << "-v #{File.expand_path(db_dir)}:/var/lib/mysql" if db_dir
+
+    def docker_extra_options
       opts.compact.join(' ')
     end
   end

--- a/lib/mcrain/rabbitmq.rb
+++ b/lib/mcrain/rabbitmq.rb
@@ -8,9 +8,16 @@ module Mcrain
     self.server_name = :rabbitmq
 
     self.container_image = "rabbitmq:3.4.4-management"
+    self.port = 15672
 
     def build_docker_command_options
       "-d -p #{runtime_port}:5672 -p #{port}:15672 --name #{container_name}"
+    end
+
+    def build_docker_options
+      r = super
+      r['HostConfig']['PortBindings']["5672/tcp"] = [{ 'HostPort': runtime_port }]
+      return r
     end
 
     def runtime_port

--- a/lib/mcrain/rabbitmq.rb
+++ b/lib/mcrain/rabbitmq.rb
@@ -10,10 +10,6 @@ module Mcrain
     self.container_image = "rabbitmq:3.4.4-management"
     self.port = 15672
 
-    def build_docker_command_options
-      "-d -p #{runtime_port}:5672 -p #{port}:15672 --name #{container_name}"
-    end
-
     def build_docker_options
       r = super
       r['HostConfig']['PortBindings']["5672/tcp"] = [{ 'HostPort': runtime_port }]

--- a/lib/mcrain/rabbitmq.rb
+++ b/lib/mcrain/rabbitmq.rb
@@ -12,7 +12,7 @@ module Mcrain
 
     def build_docker_options
       r = super
-      r['HostConfig']['PortBindings']["5672/tcp"] = [{ 'HostPort': runtime_port }]
+      r['HostConfig']['PortBindings']["5672/tcp"] = [{ 'HostPort' => runtime_port.to_s }]
       return r
     end
 

--- a/lib/mcrain/redis.rb
+++ b/lib/mcrain/redis.rb
@@ -31,5 +31,14 @@ module Mcrain
     def docker_extra_options
       db_dir ? " -v #{File.expand_path(db_dir)}:/data" : nil
     end
+
+    def build_docker_options
+      r = super
+      if db_dir
+        r['Volumes'] ||= {}
+        r['Volumes']["/data"] = File.expand_path(db_dir)
+      end
+      return r
+    end
   end
 end

--- a/lib/mcrain/redis.rb
+++ b/lib/mcrain/redis.rb
@@ -28,10 +28,6 @@ module Mcrain
 
     attr_accessor :db_dir
 
-    def docker_extra_options
-      db_dir ? " -v #{File.expand_path(db_dir)}:/data" : nil
-    end
-
     def build_docker_options
       r = super
       if db_dir

--- a/lib/mcrain/riak.rb
+++ b/lib/mcrain/riak.rb
@@ -48,7 +48,7 @@ module Mcrain
 
       def build_docker_options
         r = super
-        r['HostConfig']['PortBindings']["8098/tcp"] = [{ 'HostPort': http_port.to_s }]
+        r['HostConfig']['PortBindings']["8098/tcp"] = [{ 'HostPort' => http_port.to_s }]
         envs = []
         envs << "RIAK_CLUSTER_SIZE=#{owner.cluster_size}"
         envs << "DOCKER_RIAK_AUTOMATIC_CLUSTERING=#{owner.automatic_clustering ? 1 : 0}"

--- a/lib/mcrain/riak.rb
+++ b/lib/mcrain/riak.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require 'mcrain'
 
 # require 'riak'
@@ -157,6 +158,13 @@ module Mcrain
         c.remove
       end
       reset unless skip_reset_after_teardown
+    end
+
+    # ポートがLISTENされるまで待つ
+    def wait_port
+      nodes.each do |node|
+        Mcrain.wait_port_opened(node.host, node.port, interval: 0.5, timeout: 30)
+      end
     end
 
   end

--- a/lib/mcrain/riak.rb
+++ b/lib/mcrain/riak.rb
@@ -1,27 +1,83 @@
 require 'mcrain'
 
 # require 'riak'
+require 'net/http'
 
 module Mcrain
   class Riak < Base
 
-    class << self
-      # path to clone of https://github.com/hectcastro/docker-riak
-      attr_accessor :docker_riak_path
-    end
-
     self.server_name = :riak
 
-    self.container_image = nil # not use docker directly
-    self.port = 8087
+    self.container_image = "hectcastro/riak"
 
-    def wait
-      build_uris
-      super
+    attr_accessor :automatic_clustering
+    attr_writer :cluster_size, :backend
+    def cluster_size
+      @cluster_size ||= 1
+    end
+    def backend
+      @backend ||= "bitcask" # "leveldb"
     end
 
-    def build_client
-      super{ build_uris }
+    # docker run -e "DOCKER_RIAK_CLUSTER_SIZE=${DOCKER_RIAK_CLUSTER_SIZE}" \
+    #            -e "DOCKER_RIAK_AUTOMATIC_CLUSTERING=${DOCKER_RIAK_AUTOMATIC_CLUSTERING}" \
+    #            -e "DOCKER_RIAK_BACKEND=${DOCKER_RIAK_BACKEND}" \
+    #            -p $publish_http_port \
+    #            -p $publish_pb_port \
+    #            --link "riak01:seed" \
+    #            --name "riak${index}" \
+    #            -d hectcastro/riak > /dev/null 2>&1
+    class Node
+      include ContainerController
+
+      self.container_image = "hectcastro/riak"
+
+      self.port = 8087 # protocol buffer
+      # self.http_port = 8098 # HTTP
+
+      attr_reader :owner
+      attr_accessor :primary_node
+      def initialize(owner)
+        @owner = owner
+      end
+
+      def http_port
+        @http_port ||= find_portno
+      end
+
+      def build_docker_options
+        r = super
+        r['HostConfig']['PortBindings']["8098/tcp"] = [{ 'HostPort': http_port.to_s }]
+        envs = []
+        envs << "RIAK_CLUSTER_SIZE=#{owner.cluster_size}"
+        envs << "DOCKER_RIAK_AUTOMATIC_CLUSTERING=#{owner.automatic_clustering ? 1 : 0}"
+        envs << "DOCKER_RIAK_BACKEND=#{owner.backend}"
+        r['Env'] = envs unless envs.empty?
+        if primary_node
+          r['HostConfig']['Links'] = ["#{primary_node.container.name}:seed"]
+        end
+        return r
+      end
+
+      def ping
+        owner.logger.debug("sending a ping http://#{host}:#{http_port}/stats")
+        res = Net::HTTP.start(host, http_port) {|http| http.get('/stats') }
+        r = res.is_a?(Net::HTTPSuccess)
+        owner.logger.debug("#{res.inspect} #=> #{r}")
+        return r
+      rescue => e
+        return false
+      end
+    end
+
+    def nodes
+      unless @nodes
+        @nodes = (cluster_size || 1).times.map{ Node.new(self) }
+        array = @nodes.dup
+        primary_node = array.shift
+        array.each{|node| node.primary_node = primary_node}
+      end
+      @nodes
     end
 
     def client_class
@@ -29,53 +85,20 @@ module Mcrain
     end
 
     def client_init_args
-      options = {
-        nodes: uris.map{|uri| {host: uri.host, pb_port: uri.port} }
-      }
-      if uri = uris.first
-        if !uri.user.blank? or !uri.password.blank?
-          options[:authentication] = {user: uri.user, password: uri.password}
-        end
-      end
-      [options]
+      return [
+       {
+         nodes: nodes.map{|node| {host: node.host, pb_port: node.port} }
+       }
+      ]
     end
 
     def client_require
       'riak'
     end
 
-    def build_uris
-      # https://github.com/hectcastro/docker-riak/blob/develop/bin/test-cluster.sh#L9
-
-      # http://docs.docker.com/reference/api/docker_remote_api/
-      # https://github.com/boot2docker/boot2docker#ssh-into-vm
-      Boot2docker.setup_docker_options
-
-      uri = URI.parse(ENV["DOCKER_HOST"])
-      @host = (uri.scheme == "unix") ? "localhost" : uri.host
-      list = Docker::Container.all
-      riak_containers = list.select{|r| r.info['Image'] =~ /\Ahectcastro\/riak(\:.+)?\z/}
-      @cids = riak_containers.map(&:id)
-      @pb_ports = riak_containers.map do |r|
-        map = r.info['Ports'].each_with_object({}){|rr,d| d[ rr['PrivatePort'] ] = rr['PublicPort']}
-        map[8087]
-      end
-      @port = @pb_ports.first
-      @admin_uris = @cids.map do |cid|
-        r = Docker::Container.get(cid)
-        host = r.info["NetworkSettings"]["IPAddress"]
-        # login with insecure_key
-        # https://github.com/phusion/baseimage-docker#using-the-insecure-key-for-one-container-only
-        "ssh://root@#{host}:22"
-      end
-      @uris = @pb_ports.map do |port|
-        URI::Generic.build(scheme: "riak", host: @host, port: port)
-      end
-    end
-
     def wait_for_ready
       c = client
-      logger.debug("sending a ping")
+      logger.debug("sending a ping from client")
       begin
         r = c.ping
         raise "Ping failure with #{c.inspect}" unless r
@@ -105,54 +128,35 @@ module Mcrain
       end
     end
 
-    def clear_old_container
-    end
-
-    attr_reader :host, :cids, :pb_ports, :uris, :admin_uris
-    attr_accessor :automatic_clustering, :cluster_size
-
     def setup
-      w = @work_dir = Mcrain::Riak.docker_riak_path
-      raise "#{self.class.name}.docker_riak_path is blank. You have to set it to use the class" if w.blank?
-      raise "#{w}/Makefile not found" unless File.readable?(File.join(w, "Makefile"))
-      @prepare_cmd = Boot2docker.preparing_command
-      @automatic_clustering = false
-      @cluster_size = 1
-    end
-
-    def build_command
-      "DOCKER_RIAK_AUTOMATIC_CLUSTERING=#{automatic_clustering ? 1 : 0} DOCKER_RIAK_CLUSTER_SIZE=#{cluster_size} make start-cluster"
-    end
-
-    def run_container
-      setup
-      logger.debug("cd #{@work_dir.inspect}")
-      Dir.chdir(@work_dir) do
-        # http://basho.co.jp/riak-quick-start-with-docker/
-        #
-        # "Please wait approximately 30 seconds for the cluster to stabilize"
-        #   from https://gist.github.com/agutow/11133143#file-docker3-sh-L12
-        LoggerPipe.run(logger, "#{@prepare_cmd} #{build_command}")
-        sleep(1)
+      Boot2docker.setup_docker_options
+      nodes.map(&:container).each(&:start!)
+      # http://basho.co.jp/riak-quick-start-with-docker/
+      #
+      # "Please wait approximately 30 seconds for the cluster to stabilize"
+      #   from https://gist.github.com/agutow/11133143#file-docker3-sh-L12
+      sleep(30)
+      nodes.each do |node|
+        success = false
         20.times do
-          begin
-            LoggerPipe.run(logger, "#{@prepare_cmd} make test-cluster")
-            sleep(5)
-            return
-          rescue
-            sleep(0.5)
-            retry
-          end
+          success = node.ping
+          break if success
+          sleep(3)
         end
-        raise "failed to run a riak server"
+        raise "failed to run a riak server" unless success
       end
     end
 
-    def stop
-      Dir.chdir(@work_dir) do
-        LoggerPipe.run(logger, "#{@prepare_cmd} make stop-cluster")
+    def teardown
+      nodes.map(&:container).each do |c|
+        begin
+          c.stop!
+        rescue => e
+          c.kill!
+        end
+        c.remove
       end
-      reset unless skip_reset_after_stop
+      reset unless skip_reset_after_teardown
     end
 
   end

--- a/lib/mcrain/version.rb
+++ b/lib/mcrain/version.rb
@@ -1,3 +1,3 @@
 module Mcrain
-  VERSION = "0.1.4"
+  VERSION = "0.2.0"
 end

--- a/spec/mcrain/mysql_spec.rb
+++ b/spec/mcrain/mysql_spec.rb
@@ -24,18 +24,18 @@ describe Mcrain::Mysql do
     end
   end
 
-  context "skip_reset_after_stop" do
-    after{ Mcrain[:mysql].skip_reset_after_stop = nil }
+  context "skip_reset_after_teardown" do
+    after{ Mcrain[:mysql].skip_reset_after_teardown = nil }
 
     it false do
-      Mcrain[:mysql].skip_reset_after_stop = false
+      Mcrain[:mysql].skip_reset_after_teardown = false
       first_url = Mcrain[:mysql].url
       Mcrain[:mysql].start{ }
       expect(Mcrain[:mysql].url).to_not eq first_url
     end
 
     it true do
-      Mcrain[:mysql].skip_reset_after_stop = true
+      Mcrain[:mysql].skip_reset_after_teardown = true
       first_url = Mcrain[:mysql].url
       Mcrain[:mysql].start{ }
       expect(Mcrain[:mysql].url).to eq first_url

--- a/spec/mcrain/rabbitmq_spec.rb
+++ b/spec/mcrain/rabbitmq_spec.rb
@@ -5,7 +5,7 @@ describe Mcrain::Rabbitmq do
 
   context ".start" do
     before(:all){ Mcrain[:rabbitmq].start }
-    after(:all){ Mcrain[:rabbitmq].stop }
+    after(:all){ Mcrain[:rabbitmq].teardown }
 
     let(:s){ Mcrain[:rabbitmq] }
     it "overview" do

--- a/spec/mcrain/redis_spec.rb
+++ b/spec/mcrain/redis_spec.rb
@@ -24,18 +24,18 @@ describe Mcrain::Redis do
     end
   end
 
-  context "skip_reset_after_stop" do
-    after{ Mcrain[:redis].skip_reset_after_stop = nil }
+  context "skip_reset_after_teardown" do
+    after{ Mcrain[:redis].skip_reset_after_teardown = nil }
 
     it false do
-      Mcrain[:redis].skip_reset_after_stop = false
+      Mcrain[:redis].skip_reset_after_teardown = false
       first_url = Mcrain[:redis].url
       Mcrain[:redis].start{ }
       expect(Mcrain[:redis].url).to_not eq first_url
     end
 
     it true do
-      Mcrain[:redis].skip_reset_after_stop = true
+      Mcrain[:redis].skip_reset_after_teardown = true
       first_url = Mcrain[:redis].url
       Mcrain[:redis].start{ }
       expect(Mcrain[:redis].url).to eq first_url

--- a/spec/mcrain/riak_spec.rb
+++ b/spec/mcrain/riak_spec.rb
@@ -36,4 +36,24 @@ describe Mcrain::Riak do
     end
   end
 
+  context "allow duplicated" do
+    it do
+      Mcrain[:riak].start do |s0|
+        s0.nodes.each do |node|
+          expect(node.ping).to be_truthy
+        end
+        Mcrain::Riak.new.start do |s1|
+          s1.nodes.each do |node|
+            expect(node.ping).to be_truthy
+          end
+          Mcrain::Riak.new.start do |s2|
+            s2.nodes.each do |node|
+              expect(node.ping).to be_truthy
+            end
+          end
+        end
+      end
+    end
+  end
+
 end

--- a/spec/mcrain/riak_spec.rb
+++ b/spec/mcrain/riak_spec.rb
@@ -27,12 +27,12 @@ describe Mcrain::Riak do
 
   context "don't reset for first start" do
     it do
-      Mcrain[:riak].skip_reset_after_stop = true
-      expect(Mcrain[:riak].uris).to eq nil
+      Mcrain[:riak].skip_reset_after_teardown = true
       Mcrain[:riak].start do |s|
-        expect(s.uris).to_not be_nil
+        s.nodes.each do |node|
+          expect(node.ping).to be_truthy
+        end
       end
-      expect(Mcrain[:riak].uris).to_not be_nil
     end
   end
 

--- a/spec/mcrain/riak_spec.rb
+++ b/spec/mcrain/riak_spec.rb
@@ -38,20 +38,27 @@ describe Mcrain::Riak do
 
   context "allow duplicated" do
     it do
-      Mcrain[:riak].start do |s0|
-        s0.nodes.each do |node|
-          expect(node.ping).to be_truthy
-        end
+      Mcrain::Riak.new.start do |s0|
+        s0.nodes.each{|node| expect(node.ping).to be_truthy}
         Mcrain::Riak.new.start do |s1|
-          s1.nodes.each do |node|
-            expect(node.ping).to be_truthy
-          end
+          s0.nodes.each{|node| expect(node.ping).to be_truthy}
+          s1.nodes.each{|node| expect(node.ping).to be_truthy}
+          s0ports = s0.nodes.map(&:port)
+          s1ports = s1.nodes.map(&:port)
+          expect(s0ports - s1ports).to eq s0ports
+          expect(s1ports - s0ports).to eq s1ports
           Mcrain::Riak.new.start do |s2|
-            s2.nodes.each do |node|
-              expect(node.ping).to be_truthy
-            end
+            s0.nodes.each{|node| expect(node.ping).to be_truthy}
+            s1.nodes.each{|node| expect(node.ping).to be_truthy}
+            s2.nodes.each{|node| expect(node.ping).to be_truthy}
+            s2ports = s2.nodes.map(&:port)
+            expect(s1ports - s2ports).to eq s1ports
+            expect(s2ports - s1ports).to eq s0ports
           end
+          s1.nodes.each{|node| expect(node.ping).to be_truthy}
+          s0.nodes.each{|node| expect(node.ping).to be_truthy}
         end
+        s0.nodes.each{|node| expect(node.ping).to be_truthy}
       end
     end
   end

--- a/spec/mcrain/riak_spec.rb
+++ b/spec/mcrain/riak_spec.rb
@@ -26,6 +26,7 @@ describe Mcrain::Riak do
   end
 
   context "don't reset for first start" do
+    after{ Mcrain[:riak].skip_reset_after_teardown = nil }
     it do
       Mcrain[:riak].skip_reset_after_teardown = true
       Mcrain[:riak].start do |s|

--- a/spec/mcrain/riak_spec.rb
+++ b/spec/mcrain/riak_spec.rb
@@ -53,7 +53,7 @@ describe Mcrain::Riak do
             s2.nodes.each{|node| expect(node.ping).to be_truthy}
             s2ports = s2.nodes.map(&:port)
             expect(s1ports - s2ports).to eq s1ports
-            expect(s2ports - s1ports).to eq s0ports
+            expect(s2ports - s1ports).to eq s2ports
           end
           s1.nodes.each{|node| expect(node.ping).to be_truthy}
           s0.nodes.each{|node| expect(node.ping).to be_truthy}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 require "pry"
 
+unless ENV['DOCKER_HOST']
+  raise 'DOCKER_HOST is not exported. use `$(boot2docker shellinit)` or set DOCKER_HOST like tcp://127.0.0.1:2375'
+end
+
 if ENV["COVERAGE"] =~ /true|yes|on|1/i
   require "simplecov"
   SimpleCov.start :rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,3 @@ require 'mcrain'
 Dir.mkdir("log") unless Dir.exist?("log")
 Mcrain.logger = Logger.new("log/test.log")
 Mcrain.logger.level = Logger::DEBUG
-
-# TODO use submodule after move to independent repository
-Mcrain::Riak.docker_riak_path = File.expand_path("../support/docker-riak", __FILE__)


### PR DESCRIPTION
use Docker HTTP API instead of docker command to start and stop container.

It's possible to run same typed containers at the same time.
## reviewers
- [x] @nagachika 
- [x] @minimum2scp 
