### PR TITLE
create remote dir to mount volumes for boot2docker

### DIFF
--- a/lib/mcrain/base.rb
+++ b/lib/mcrain/base.rb
@@ -82,7 +82,7 @@ module Mcrain
       rescue => e
         container.kill!
       end
-      container.remove
+      container.remove unless ENV['MCRAIN_KEEP_CONTAINERS'] =~ /true|yes|on|1/i
     end
 
   end

--- a/lib/mcrain/boot2docker.rb
+++ b/lib/mcrain/boot2docker.rb
@@ -3,6 +3,7 @@ require 'mcrain'
 require 'uri'
 require 'fileutils'
 require 'rbconfig'
+require 'tmpdir'
 
 require 'net/scp'
 require 'docker'
@@ -67,6 +68,13 @@ module Mcrain
           scp.download(src, dest)
         end
       end
+    end
+
+    BOOT2DOCKER_DOCKER_HOME = '/home/docker'.freeze
+
+    # return temporary dire for 2nd argument of Dir.mktmpdir
+    def tmpdir
+      used? ? BOOT2DOCKER_DOCKER_HOME : Dir.tmpdir
     end
 
   end

--- a/lib/mcrain/boot2docker.rb
+++ b/lib/mcrain/boot2docker.rb
@@ -74,7 +74,7 @@ module Mcrain
 
     # return temporary dire for 2nd argument of Dir.mktmpdir
     def tmpdir
-      used? ? BOOT2DOCKER_DOCKER_HOME : Dir.tmpdir
+      used? ? File.join(BOOT2DOCKER_DOCKER_HOME, 'tmp', Dir.tmpdir) : Dir.tmpdir
     end
 
   end

--- a/lib/mcrain/boot2docker.rb
+++ b/lib/mcrain/boot2docker.rb
@@ -91,20 +91,24 @@ module Mcrain
     end
 
     def mktmpdir_ssh(&block)
+      ssh_to_vm do |ssh|
+        return mktmpdir_remote(ssh, &block)
+      end
+    end
+
+    def mktmpdir_remote(ssh, &block)
       Dir.mktmpdir do |orig_dir|
         dir = File.join(BOOT2DOCKER_DOCKER_HOME, 'tmp', orig_dir)
-        ssh_to_vm do |ssh|
-          cmd1 = "mkdir -p #{dir}"
-          Mcrain.logger.debug(cmd1)
-          ssh.exec! cmd1
-          yield(dir) if block_given?
-          begin
-            cmd2 = "rm -rf #{dir}"
-            Mcrain.logger.debug(cmd2)
-            ssh.exec! cmd2
-          rescue => e
-            Mcrain.logger.warn("[#{e.class}] #{e.message}")
-          end
+        cmd1 = "mkdir -p #{dir}"
+        Mcrain.logger.debug(cmd1)
+        ssh.exec! cmd1
+        yield(dir) if block_given?
+        begin
+          cmd2 = "rm -rf #{dir}"
+          Mcrain.logger.debug(cmd2)
+          ssh.exec! cmd2
+        rescue => e
+          Mcrain.logger.warn("[#{e.class}] #{e.message}")
         end
         return dir
       end

--- a/lib/mcrain/version.rb
+++ b/lib/mcrain/version.rb
@@ -1,3 +1,3 @@
 module Mcrain
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/spec/mcrain/mysql_spec.rb
+++ b/spec/mcrain/mysql_spec.rb
@@ -14,7 +14,7 @@ describe Mcrain::Mysql do
 
     context "with db_dir" do
       around do |example|
-        Dir.mktmpdir do |dir|
+        Dir.mktmpdir(nil, Mcrain::Boot2docker.tmpdir) do |dir|
           @tmp_db_dir = dir
           example.run
         end

--- a/spec/mcrain/mysql_spec.rb
+++ b/spec/mcrain/mysql_spec.rb
@@ -14,7 +14,7 @@ describe Mcrain::Mysql do
 
     context "with db_dir" do
       around do |example|
-        Dir.mktmpdir(nil, Mcrain::Boot2docker.tmpdir) do |dir|
+        Mcrain::Boot2docker.mktmpdir do |dir|
           @tmp_db_dir = dir
           example.run
         end

--- a/spec/mcrain/mysql_spec.rb
+++ b/spec/mcrain/mysql_spec.rb
@@ -27,8 +27,10 @@ describe Mcrain::Mysql do
       let(:tabledata1){ "FOO" }
 
       it do
+        old_cid = nil
         Mcrain[:mysql].db_dir = tmp_db_dir
         Mcrain[:mysql].start do |s|
+          old_cid = s.container.id
           c0 = s.build_client
           c0.query("CREATE DATABASE #{dbname}")
           c0.select_db(dbname)
@@ -37,6 +39,7 @@ describe Mcrain::Mysql do
         end
         Mcrain[:mysql].db_dir = tmp_db_dir
         Mcrain[:mysql].start do |s|
+          expect(s.container.id).to_not eq old_cid
           c1 = s.build_client
           c1.select_db(dbname)
           expect(c1.query("SELECT NAME FROM #{tablename}").map(&:to_hash)).to eq [{"NAME"=> tabledata1}]


### PR DESCRIPTION
- define Mcrain::Boot2docker.mktmpdir to make directory on VM of boot2docker if it is needed
- add MCRAIN_KEEP_CONTAINERS to avoid removing used containers
## reviewers
- [x] @nagachika 
- [x] @minimum2scp 
