### PR TITLE
add Mcrain::Base#ip to get container IP

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
---format documentation
+--format Fuubar
 --color

--- a/lib/mcrain/base.rb
+++ b/lib/mcrain/base.rb
@@ -31,6 +31,10 @@ module Mcrain
           wait_port
           wait
           return yield(self)
+        rescue Exception => e
+          logs = container.logs(stdout: 1, stderr: 1)
+          logger.error("[#{e.class.name}] #{e.message}\nthe container logs...\n#{logs}")
+          raise e
         ensure
           teardown
         end

--- a/lib/mcrain/container_controller.rb
+++ b/lib/mcrain/container_controller.rb
@@ -68,5 +68,12 @@ module Mcrain
       self
     end
 
+    def ip
+      container.json["NetworkSettings"]["IPAddress"]
+    end
+
+    def ssh_uri
+      "ssh://root@#{ip}:22"
+    end
   end
 end

--- a/lib/mcrain/riak.rb
+++ b/lib/mcrain/riak.rb
@@ -69,6 +69,12 @@ module Mcrain
       rescue => e
         return false
       end
+
+      def reset
+        instance_variables.each do |var|
+          instance_variable_set(var, nil)
+        end
+      end
     end
 
     def nodes
@@ -79,6 +85,11 @@ module Mcrain
         array.each{|node| node.primary_node = primary_node}
       end
       @nodes
+    end
+
+    def reset
+      (@nodes || []).each(&:reset)
+      super
     end
 
     def client_class

--- a/lib/mcrain/riak.rb
+++ b/lib/mcrain/riak.rb
@@ -144,7 +144,14 @@ module Mcrain
           break if success
           sleep(3)
         end
-        raise "failed to run a riak server" unless success
+        unless success
+          msg = "failed to run a riak server"
+          timeout(10) do
+            logs = node.container.logs(stdout: 1, stderr: 1)
+            logger.error("#{msg}\nthe container logs...\n#{logs}")
+          end
+          raise msg
+        end
       end
     end
 

--- a/lib/mcrain/version.rb
+++ b/lib/mcrain/version.rb
@@ -1,3 +1,3 @@
 module Mcrain
-  VERSION = "0.2.3"
+  VERSION = "0.3.0"
 end

--- a/spec/mcrain/mysql_spec.rb
+++ b/spec/mcrain/mysql_spec.rb
@@ -74,9 +74,13 @@ describe Mcrain::Mysql do
 
     it true do
       Mcrain[:mysql].skip_reset_after_teardown = true
-      first_url = Mcrain[:mysql].url
-      Mcrain[:mysql].start{ }
-      expect(Mcrain[:mysql].url).to eq first_url
+      begin
+        first_url = Mcrain[:mysql].url
+        Mcrain[:mysql].start{ }
+        expect(Mcrain[:mysql].url).to eq first_url
+      ensure
+        Mcrain[:mysql].reset
+      end
     end
   end
 

--- a/spec/mcrain/redis_spec.rb
+++ b/spec/mcrain/redis_spec.rb
@@ -55,4 +55,15 @@ describe Mcrain::Redis do
     end
   end
 
+  # docker inspect -f "{{.NetworkSettings.IPAddress}}\t{{.Config.Hostname}}\t#{{.Name}}\t({{.Config.Image}})" `docker ps -q`
+  context ".NetworkSettings.IPAddress" do
+    it do
+      Mcrain[:redis].start do |s|
+        ip = s.ip
+        expect(ip).to_not eq s.host
+        expect(s.ssh_uri).to eq "ssh://root@#{ip}:22"
+      end
+    end
+  end
+
 end

--- a/spec/mcrain/redis_spec.rb
+++ b/spec/mcrain/redis_spec.rb
@@ -49,9 +49,13 @@ describe Mcrain::Redis do
 
     it true do
       Mcrain[:redis].skip_reset_after_teardown = true
-      first_url = Mcrain[:redis].url
-      Mcrain[:redis].start{ }
-      expect(Mcrain[:redis].url).to eq first_url
+      begin
+        first_url = Mcrain[:redis].url
+        Mcrain[:redis].start{ }
+        expect(Mcrain[:redis].url).to eq first_url
+      ensure
+        Mcrain[:redis].reset # reset manually
+      end
     end
   end
 

--- a/spec/mcrain/riak_spec.rb
+++ b/spec/mcrain/riak_spec.rb
@@ -64,4 +64,18 @@ describe Mcrain::Riak do
     end
   end
 
+  # docker inspect -f "{{.NetworkSettings.IPAddress}}\t{{.Config.Hostname}}\t#{{.Name}}\t({{.Config.Image}})" `docker ps -q`
+  context ".NetworkSettings.IPAddress" do
+    after{ Mcrain[:riak].skip_reset_after_teardown = nil }
+    it do
+      Mcrain[:riak].start do |s|
+        s.nodes.each do |node|
+          ip = node.ip
+          expect(ip).to_not eq node.host
+          expect(node.ssh_uri).to eq "ssh://root@#{ip}:22"
+        end
+      end
+    end
+  end
+
 end

--- a/spec/mcrain/riak_spec.rb
+++ b/spec/mcrain/riak_spec.rb
@@ -29,10 +29,14 @@ describe Mcrain::Riak do
     after{ Mcrain[:riak].skip_reset_after_teardown = nil }
     it do
       Mcrain[:riak].skip_reset_after_teardown = true
-      Mcrain[:riak].start do |s|
-        s.nodes.each do |node|
-          expect(node.ping).to be_truthy
+      begin
+        Mcrain[:riak].start do |s|
+          s.nodes.each do |node|
+            expect(node.ping).to be_truthy
+          end
         end
+      ensure
+        Mcrain[:riak].reset # manually
       end
     end
   end


### PR DESCRIPTION
Add Mcrain::Base#ip to get contaier IP (.NetworkSettings.IPAddress). It can be used to connect to container via SSH.

And fix examples which use skip_reset_after_teardown. They call #reset method at the end of them.

Version is bumped up from 0.2.3 to 0.3.0
## reviewers
- [x] @nagachika 
- [x] @minimum2scp 
