### PR TITLE
fix riak clustering

### DIFF
--- a/lib/mcrain/container_controller.rb
+++ b/lib/mcrain/container_controller.rb
@@ -68,8 +68,16 @@ module Mcrain
       self
     end
 
+    def info
+      container.json
+    end
+
+    def name
+      info["Name"] # .sub(/\A\//, '')
+    end
+
     def ip
-      container.json["NetworkSettings"]["IPAddress"]
+      info["NetworkSettings"]["IPAddress"]
     end
 
     def ssh_uri

--- a/lib/mcrain/riak.rb
+++ b/lib/mcrain/riak.rb
@@ -142,8 +142,11 @@ module Mcrain
 
     def setup
       Boot2docker.setup_docker_options
-      setup_nodes(nodes[0, 1]) # primary node
-      setup_nodes(nodes[1..-1])
+      # setup_nodes(nodes[0, 1]) # primary node
+      # setup_nodes(nodes[1..-1])
+      nodes.each do |node|
+        setup_nodes([node])
+      end
     end
 
     def setup_nodes(nodes)

--- a/lib/mcrain/version.rb
+++ b/lib/mcrain/version.rb
@@ -1,3 +1,3 @@
 module Mcrain
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/mcrain/riak_spec.rb
+++ b/spec/mcrain/riak_spec.rb
@@ -23,6 +23,21 @@ describe Mcrain::Riak do
         expect(s.client).to_not eq first
       end
     end
+
+    it "clustering" do
+      riak = Mcrain::Riak.new
+      riak.cluster_size = 5
+      riak.automatic_clustering = true
+      riak.start do |s|
+        c = s.client
+        obj1 = c.bucket("bucket1").get_or_new("foo")
+        obj1.data = data
+        obj1.store
+        obj2 = c.bucket("bucket1").get_or_new("foo")
+        expect(obj2.content_type).to eq "application/json"
+        expect(JSON.parse(obj2.raw_data)).to eq data
+      end
+    end
   end
 
   context "don't reset for first start" do


### PR DESCRIPTION
- setup nodes sequentially not parallel
- rename RIAK_CLUSTER_SIZE  to DOCKER_RIAK_CLUSTER_SIZE
- fix primary node container name which is used for links option
## reviewers
- [x] @nagachika 
- [x] @minimum2scp 
