### PR TITLE
add Mcrain::Boot2docker.cp_r to copy directory to local or remote directory

### DIFF
--- a/lib/mcrain/version.rb
+++ b/lib/mcrain/version.rb
@@ -1,3 +1,3 @@
 module Mcrain
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/spec/mcrain/redis_spec.rb
+++ b/spec/mcrain/redis_spec.rb
@@ -14,10 +14,9 @@ describe Mcrain::Redis do
 
     it "with db_dir" do
       Mcrain::Boot2docker.mktmpdir do |dir|
-        tmp_db_dir = File.join(dir, "db_dir")
-        FileUtils.cp_r(File.expand_path("../redis_spec/db_dir", __FILE__), tmp_db_dir)
+        Mcrain::Boot2docker.cp_r(File.expand_path("../redis_spec/db_dir", __FILE__), dir)
         redis_server = Mcrain[:redis].tap do |s|
-          s.db_dir = tmp_db_dir
+          s.db_dir = File.join(dir, "db_dir")
         end
         redis_server.start do |s|
           expect(s.client.get("foo")).to eq '1000'

--- a/spec/mcrain/redis_spec.rb
+++ b/spec/mcrain/redis_spec.rb
@@ -13,13 +13,17 @@ describe Mcrain::Redis do
     after{ Mcrain[:redis].db_dir = nil }
 
     it "with db_dir" do
-      redis_server = Mcrain[:redis].tap do |s|
-        s.db_dir = File.expand_path("../redis_spec/db_dir", __FILE__)
-      end
-      redis_server.start do |s|
-        expect(s.client.get("foo")).to eq '1000'
-        expect(s.client.get("bar")).to eq '2000'
-        expect(s.client.get("baz")).to eq '3000'
+      Mcrain::Boot2docker.mktmpdir do |dir|
+        tmp_db_dir = File.join(dir, "db_dir")
+        FileUtils.cp_r(File.expand_path("../redis_spec/db_dir", __FILE__), tmp_db_dir)
+        redis_server = Mcrain[:redis].tap do |s|
+          s.db_dir = tmp_db_dir
+        end
+        redis_server.start do |s|
+          expect(s.client.get("foo")).to eq '1000'
+          expect(s.client.get("bar")).to eq '2000'
+          expect(s.client.get("baz")).to eq '3000'
+        end
       end
     end
   end


### PR DESCRIPTION
docker containers change mounted volume directory's owner for writing like this:

```
jenkins@ci-unittest01:~/jobs/MASTER-mcrain/workspace$ ls -la spec/mcrain/redis_spec/db_dir
total 12
drwxr-xr-x 2     999 jenkins 4096 Aug 12 12:42 .
drwxr-xr-x 3 jenkins jenkins 4096 Aug 12 12:42 ..
-rw-r--r-- 1     999 jenkins   44 Aug 12 12:42 dump.rdb
```

To avoid to change owner, this pull request add a method Mcrain::Boot2docker.cp_r. This method copy directory to local or remote directory automatically.
### Before

Original db directory is mounted for container.
If boot2docker is used, it copy the directory to remote directory automatically and mount remote copied directory. This is OK.
If boot2docker is NOT used, local directory is mounted directory and its owner is changed by docker container. This is NOT OK.
### After

If boot2docker is used,
1. make tmp directory locally
2. copy the source directory to tmp directory
3. make tarball for the copied source directory
4. make tmp directory remotely
5. upload tarball to remote tmp directory
6. extract tarball to directory remotely
7. container uses remote directory in remote tmp directory to mount

If boot2docker is NOT used,
1. make tmp directory locally
2. copy the source directory to tmp directory
3. container uses the directory in local tmp directory to mount
## reviewers
- [x] @nagachika 
- [x] @minimum2scp 
