### PR TITLE
add Mcrain.before_setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,26 @@ $ mcrain stop riak 5
 OK
 ```
 
+## Mcrain.before_setup
+
+Use Mcrain.before_setup hook if you don't want your test or spec always works with mcrain.
+Set block to Mcrain.before_setup like this:
+
+```ruby
+unless ENV['WITH_MCRAIN'] =~ /true|yes|on|1/i
+  Mcrain.before_setup = ->(s){
+    # RSpec::Core::Pending#skip
+    # https://github.com/rspec/rspec-core/blob/5fc29a15b9af9dc1c9815e278caca869c4769767/lib/rspec/core/pending.rb#L118-L124
+    message = "skip examples which uses mcrain"
+    current_example = RSpec.current_example
+    RSpec::Core::Pending.mark_skipped!(current_example, message) if current_example
+    raise RSpec::Core::Pending::SkipDeclaredInExample.new(message)
+  }
+end
+```
+
+
+
 
 ## Development
 

--- a/lib/mcrain.rb
+++ b/lib/mcrain.rb
@@ -78,6 +78,7 @@ module Mcrain
       end
     end
 
+    attr_accessor :before_setup
   end
 
   autoload :Base, 'mcrain/base'

--- a/lib/mcrain/riak.rb
+++ b/lib/mcrain/riak.rb
@@ -139,6 +139,7 @@ module Mcrain
     end
 
     def setup
+      return false if Mcrain.before_setup && !Mcrain.before_setup.call(self)
       DockerMachine.setup_docker_options
       # setup_nodes(nodes[0, 1]) # primary node
       # setup_nodes(nodes[1..-1])

--- a/lib/mcrain/version.rb
+++ b/lib/mcrain/version.rb
@@ -1,3 +1,3 @@
 module Mcrain
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/mcrain/before_setup_spec.rb
+++ b/spec/mcrain/before_setup_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Mcrain::Base do
+  before{ @before_setup_backup = Mcrain.before_setup }
+  after{ Mcrain.before_setup = @before_setup_backup }
+
+  [Mcrain::Mysql, Mcrain::Rabbitmq, Mcrain::Redis, Mcrain::Riak].each do |server_class|
+    context server_class do
+      it "starts with before_setup which returns true" do
+        called = []
+        given_server = nil
+        Mcrain.before_setup = ->(s){ given_server = s; called << "before_setup-block"; true }
+        server = server_class.new
+        expect(server).to receive(:start_callback).and_call_original
+        r = server.start do |s|
+          called << "start-block"
+        end
+        expect(r).to eq server
+        expect(given_server).to eq server
+        expect(called).to eq ["before_setup-block", "start-block"]
+      end
+
+      it "doesn't starts with before_setup which returns false" do
+        called = []
+        given_server = nil
+        Mcrain.before_setup = ->(s){ given_server = s; called << "before_setup-block"; false }
+        server = server_class.new
+        expect(server).not_to receive(:start_callback)
+        r = server.start do |s|
+          called << "start-block"
+        end
+        expect(r).to eq nil
+        expect(given_server).to eq server
+        expect(called).to eq ["before_setup-block"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add Mcrain.before_setup for global control to skip container launch.
Add the usage to README.md.
## reviewers
- [x] @nagachika 
- [x] @minimum2scp 
