### PR TITLE
remove bracket method of mcrain

### DIFF
--- a/lib/mcrain.rb
+++ b/lib/mcrain.rb
@@ -12,17 +12,6 @@ require 'active_support/core_ext/numeric/time'
 
 module Mcrain
   class << self
-    def [](name)
-      lookup(name)
-    end
-
-    def lookup(name, options = {})
-      klass = class_for(name.to_sym)
-      r = instances[name] ||= klass.new
-      options.each{|k,v| r.send("#{k}=", v)}
-      r
-    end
-
     def class_names
       @class_names ||= {}
     end
@@ -40,10 +29,6 @@ module Mcrain
 
     def register(name, class_name)
       class_names[name] = class_name
-    end
-
-    def instances
-      @instances ||= {}
     end
 
     DEFAULT_IMAGES = {

--- a/lib/mcrain/base.rb
+++ b/lib/mcrain/base.rb
@@ -24,6 +24,12 @@ module Mcrain
       end
     end
 
+    def initialize(attrs = {})
+      attrs.each do |key, value|
+        send("#{key}=", value)
+      end
+    end
+
     def start(&block)
       r = setup
       return nil unless r

--- a/lib/mcrain/version.rb
+++ b/lib/mcrain/version.rb
@@ -1,3 +1,3 @@
 module Mcrain
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/spec/mcrain/mysql_spec.rb
+++ b/spec/mcrain/mysql_spec.rb
@@ -7,7 +7,7 @@ describe Mcrain::Mysql do
 
   context ".start" do
     it "ping" do
-      Mcrain[:mysql].start do |s|
+      Mcrain::Mysql.new.start do |s|
         expect(s.client.query("show databases").map(&:values).flatten.sort).to eq ["information_schema", "mysql", "performance_schema"].sort
       end
     end
@@ -20,7 +20,6 @@ describe Mcrain::Mysql do
         end
       end
       let(:tmp_db_dir){ @tmp_db_dir }
-      after { Mcrain[:mysql].db_dir = nil }
 
       let(:dbname){ "testdb1" }
       let(:tablename){ "testtable1" }
@@ -28,8 +27,7 @@ describe Mcrain::Mysql do
 
       it do
         old_cid = nil
-        Mcrain[:mysql].db_dir = tmp_db_dir
-        Mcrain[:mysql].start do |s|
+        Mcrain::Mysql.new(db_dir: tmp_db_dir).start do |s|
           old_cid = s.container.id
           c0 = s.build_client
           c0.query("CREATE DATABASE #{dbname}")
@@ -37,8 +35,7 @@ describe Mcrain::Mysql do
           c0.query("CREATE TABLE #{tablename} (id integer NOT NULL AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255) NOT NULL);")
           c0.query("INSERT INTO #{tablename} (name) VALUES ('#{tabledata1}');")
         end
-        Mcrain[:mysql].db_dir = tmp_db_dir
-        Mcrain[:mysql].start do |s|
+        Mcrain::Mysql.new(db_dir: tmp_db_dir).start do |s|
           expect(s.container.id).to_not eq old_cid
           c1 = s.build_client
           c1.select_db(dbname)
@@ -52,34 +49,32 @@ describe Mcrain::Mysql do
   context "start twice" do
     it do
       first = nil
-      Mcrain[:mysql].start do |s|
+      Mcrain::Mysql.new.start do |s|
         first = s.client
         expect(s.client).to eq first
       end
-      Mcrain[:mysql].start do |s|
+      Mcrain::Mysql.new.start do |s|
         expect(s.client).to_not eq first
       end
     end
   end
 
   context "skip_reset_after_teardown" do
-    after{ Mcrain[:mysql].skip_reset_after_teardown = nil }
-
     it false do
-      Mcrain[:mysql].skip_reset_after_teardown = false
-      first_url = Mcrain[:mysql].url
-      Mcrain[:mysql].start{ }
-      expect(Mcrain[:mysql].url).to_not eq first_url
+      s = Mcrain::Mysql.new(skip_reset_after_teardown: false)
+      first_url = s.url
+      s.start{ }
+      expect(s.url).to_not eq first_url
     end
 
     it true do
-      Mcrain[:mysql].skip_reset_after_teardown = true
+      s = Mcrain::Mysql.new(skip_reset_after_teardown: true)
       begin
-        first_url = Mcrain[:mysql].url
-        Mcrain[:mysql].start{ }
-        expect(Mcrain[:mysql].url).to eq first_url
+        first_url = s.url
+        s.start{ }
+        expect(s.url).to eq first_url
       ensure
-        Mcrain[:mysql].reset
+        s.reset
       end
     end
   end

--- a/spec/mcrain/rabbitmq_spec.rb
+++ b/spec/mcrain/rabbitmq_spec.rb
@@ -4,10 +4,13 @@ require 'spec_helper'
 describe Mcrain::Rabbitmq do
 
   context ".start" do
-    before(:all){ Mcrain[:rabbitmq].start }
-    after(:all){ Mcrain[:rabbitmq].teardown }
+    before(:all){
+      @rabbitmq = Mcrain::Rabbitmq.new
+      @rabbitmq.start
+    }
+    after(:all){ @rabbitmq.teardown }
 
-    let(:s){ Mcrain[:rabbitmq] }
+    let(:s){ @rabbitmq }
     it "overview" do
       nodes = s.client.list_nodes
       expect(nodes.length).to eq 1
@@ -23,11 +26,11 @@ describe Mcrain::Rabbitmq do
   context "start twice" do
     it do
       first = nil
-      Mcrain[:rabbitmq].start do |s|
+      Mcrain::Rabbitmq.new.start do |s|
         first = s.client
         expect(s.client).to eq first
       end
-      Mcrain[:rabbitmq].start do |s|
+      Mcrain::Rabbitmq.new.start do |s|
         expect(s.client).to_not eq first
       end
     end
@@ -35,11 +38,12 @@ describe Mcrain::Rabbitmq do
 
   context "don't reset for first start" do
     it do
-      first_url = Mcrain[:rabbitmq].url
-      Mcrain[:rabbitmq].start do |s|
-        expect(s.url).to eq first_url
+      s = Mcrain::Rabbitmq.new
+      first_url = s.url
+      s.start do |s1|
+        expect(s1.url).to eq first_url
       end
-      expect(Mcrain[:rabbitmq].url).to_not eq first_url
+      expect(s.url).to_not eq first_url
     end
   end
 

--- a/spec/mcrain/redis_spec.rb
+++ b/spec/mcrain/redis_spec.rb
@@ -5,19 +5,15 @@ describe Mcrain::Redis do
 
   context ".start" do
     it "ping" do
-      Mcrain[:redis].start do |s|
+      Mcrain::Redis.new.start do |s|
         expect(s.client.ping).to eq "PONG"
       end
     end
 
-    after{ Mcrain[:redis].db_dir = nil }
-
     it "with db_dir" do
       Mcrain::DockerMachine.mktmpdir do |dir|
         Mcrain::DockerMachine.cp_r(File.expand_path("../redis_spec/db_dir", __FILE__), dir)
-        redis_server = Mcrain[:redis].tap do |s|
-          s.db_dir = File.join(dir, "db_dir")
-        end
+        redis_server = Mcrain::Redis.new(db_dir: File.join(dir, "db_dir"))
         redis_server.start do |s|
           expect(s.client.get("foo")).to eq '1000'
           expect(s.client.get("bar")).to eq '2000'
@@ -30,34 +26,32 @@ describe Mcrain::Redis do
   context "start twice" do
     it do
       first = nil
-      Mcrain[:redis].start do |s|
+      Mcrain::Redis.new.start do |s|
         first = s.client
         expect(s.client).to eq first
       end
-      Mcrain[:redis].start do |s|
+      Mcrain::Redis.new.start do |s|
         expect(s.client).to_not eq first
       end
     end
   end
 
   context "skip_reset_after_teardown" do
-    after{ Mcrain[:redis].skip_reset_after_teardown = nil }
-
     it false do
-      Mcrain[:redis].skip_reset_after_teardown = false
-      first_url = Mcrain[:redis].url
-      Mcrain[:redis].start{ }
-      expect(Mcrain[:redis].url).to_not eq first_url
+      s = Mcrain::Redis.new(skip_reset_after_teardown: false)
+      first_url = s.url
+      s.start{ }
+      expect(s.url).to_not eq first_url
     end
 
     it true do
-      Mcrain[:redis].skip_reset_after_teardown = true
+      s = Mcrain::Redis.new(skip_reset_after_teardown: true)
       begin
-        first_url = Mcrain[:redis].url
-        Mcrain[:redis].start{ }
-        expect(Mcrain[:redis].url).to eq first_url
+        first_url = s.url
+        s.start{ }
+        expect(s.url).to eq first_url
       ensure
-        Mcrain[:redis].reset # reset manually
+        s.reset # reset manually
       end
     end
   end
@@ -65,7 +59,7 @@ describe Mcrain::Redis do
   # docker inspect -f "{{.NetworkSettings.IPAddress}}\t{{.Config.Hostname}}\t#{{.Name}}\t({{.Config.Image}})" `docker ps -q`
   context ".NetworkSettings.IPAddress" do
     it do
-      Mcrain[:redis].start do |s|
+      Mcrain::Redis.new.start do |s|
         ip = s.ip
         expect(ip).to_not eq s.host
         expect(s.ssh_uri).to eq "ssh://root@#{ip}:22"

--- a/spec/mcrain/riak/reset_spec.rb
+++ b/spec/mcrain/riak/reset_spec.rb
@@ -3,17 +3,16 @@ require 'spec_helper'
 describe Mcrain::Riak do
 
   context "don't reset for first start" do
-    after{ Mcrain[:riak].skip_reset_after_teardown = nil }
     it do
-      Mcrain[:riak].skip_reset_after_teardown = true
+      riak = Mcrain::Riak.new(skip_reset_after_teardown: true)
       begin
-        Mcrain[:riak].start do |s|
+        riak.start do |s|
           s.nodes.each do |node|
             expect(node.ping).to be_truthy
           end
         end
       ensure
-        Mcrain[:riak].reset # manually
+        riak.reset # manually
       end
     end
   end

--- a/spec/mcrain/riak/ssh_uri_spec.rb
+++ b/spec/mcrain/riak/ssh_uri_spec.rb
@@ -4,9 +4,8 @@ describe Mcrain::Riak do
 
   # docker inspect -f "{{.NetworkSettings.IPAddress}}\t{{.Config.Hostname}}\t#{{.Name}}\t({{.Config.Image}})" `docker ps -q`
   context ".NetworkSettings.IPAddress" do
-    after{ Mcrain[:riak].skip_reset_after_teardown = nil }
     it do
-      Mcrain[:riak].start do |s|
+      Mcrain::Riak.new.start do |s|
         s.nodes.each do |node|
           ip = node.ip
           expect(ip).to_not eq node.host

--- a/spec/mcrain/riak_spec.rb
+++ b/spec/mcrain/riak_spec.rb
@@ -6,7 +6,7 @@ describe Mcrain::Riak do
     let(:data){ {"foo" => {"bar" => "baz"}} }
     it do
       first = nil
-      Mcrain[:riak].start do |s|
+      Mcrain::Riak.new.start do |s|
         c = s.client
         obj1 = c.bucket("bucket1").get_or_new("foo")
         obj1.data = data
@@ -19,7 +19,7 @@ describe Mcrain::Riak do
         first = s.client
         expect(s.client).to eq first
       end
-      Mcrain[:riak].start do |s|
+      Mcrain::Riak.new.start do |s|
         expect(s.client).to_not eq first
       end
     end

--- a/spec/mcrain_spec.rb
+++ b/spec/mcrain_spec.rb
@@ -5,10 +5,4 @@ describe Mcrain do
     expect(Mcrain::VERSION).not_to be nil
   end
 
-  context ".[]" do
-    it{ expect(Mcrain[:redis]).to be_a Mcrain::Redis }
-    it{ expect(Mcrain[:redis]).to eq Mcrain[:redis] }
-    it{ expect{Mcrain[:not_found]}.to raise_error }
-  end
-
 end


### PR DESCRIPTION
In order to avoid the dificulty to handle the instance which instantiated by Mcrain.[], remove the method.
And add constructor to Mcrain::Base to assign attributes easily.
## reviewers
- [x] @nagachika 
- [x] @minimum2scp 
