### PR TITLE
Mcrain::Hbase

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,13 +15,14 @@ group :development do
   gem "riak-client"
 
   # for mysql
-  gem "mysql2"
+  gem "mysql2", platform: "ruby"
+  # gem "jdbc-mysql", platform: "jruby" # this is not supported yet.
 end
 
 group :development do
   gem "pry"
-  gem "pry-byebug"
-  gem "pry-stack_explorer"
+  gem "pry-byebug", platform: "ruby"
+  gem "pry-stack_explorer", platform: "ruby"
   gem "simplecov"
   gem "fuubar"
   gem "parallel_tests"

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,9 @@ group :development do
   # for mysql
   gem "mysql2", platform: "ruby"
   # gem "jdbc-mysql", platform: "jruby" # this is not supported yet.
+
+  # for HBase
+  gem "hbase-jruby", platform: "jruby"
 end
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Or install it yourself as:
 
 middleware | client gem
 -----------|-------------
+MySQL      | `gem 'mysql2'`
 Redis      | `gem 'redis'`
 RabbitMQ   | `gem 'rabbitmq_http_api_client', '>= 1.6.0'`
 Riak       | `gem 'docker-api', '~> 1.21.1'; gem 'riak-client'`

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Or install it yourself as:
 middleware | client gem (CRuby)  | client gem (JRuby)
 -----------|---------------------|------------------
 MySQL      | `gem 'mysql2'`      | N/A
-Redis      | `gem 'redis'`       | the same as CRuby
-RabbitMQ   | `gem 'rabbitmq_http_api_client', '>= 1.6.0'`       | the same as CRuby
-Riak       | `gem 'docker-api', '~> 1.21.1'; gem 'riak-client'` | the same as CRuby
-HBase      | N/A                 | gem 'hbase-jruby'
+Redis      | `gem 'redis'`       | (the same as CRuby)
+RabbitMQ   | `gem 'rabbitmq_http_api_client', '>= 1.6.0'`       | (the same as CRuby)
+Riak       | `gem 'docker-api', '~> 1.21.1'; gem 'riak-client'` | (the same as CRuby)
+HBase      | N/A                 | `gem 'hbase-jruby'`
 
 
 ## Usage
@@ -107,19 +107,12 @@ end
 
 Mcrain::Hbase uses [nerdammer/hbase](https://hub.docker.com/r/nerdammer/hbase).
 
-add hostname to /etc/hosts befoe use it
+Add a line like this to /etc/hosts
 
-With docker toolbox
-
-```
-192.168.99.100 docker-host1
-```
-
-Without docker toolbox
-
-```
-127.0.0.1 docker-host1
-```
+|      |       |
+|------|-------|
+| With docker toolbox    | `192.168.99.100 docker-host1` |
+| Without docker toolbox | `127.0.0.1 docker-host1` |
 
 
 ```ruby
@@ -191,17 +184,12 @@ OK
 
 add hostname to /etc/hosts befoe use it
 
-With docker toolbox
+Add a line like this to /etc/hosts
 
-```
-192.168.99.100 docker-host1
-```
-
-Without docker toolbox
-
-```
-127.0.0.1 docker-host1
-```
+|      |       |
+|------|-------|
+| With docker toolbox    | `192.168.99.100 docker-host1` |
+| Without docker toolbox | `127.0.0.1 docker-host1` |
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -61,12 +61,13 @@ Or install it yourself as:
 
 ### with middleware clients
 
-middleware | client gem
------------|-------------
-MySQL      | `gem 'mysql2'`
-Redis      | `gem 'redis'`
-RabbitMQ   | `gem 'rabbitmq_http_api_client', '>= 1.6.0'`
-Riak       | `gem 'docker-api', '~> 1.21.1'; gem 'riak-client'`
+middleware | client gem (CRuby)  | client gem (JRuby)
+-----------|---------------------|------------------
+MySQL      | `gem 'mysql2'`      | N/A
+Redis      | `gem 'redis'`       | the same as CRuby
+RabbitMQ   | `gem 'rabbitmq_http_api_client', '>= 1.6.0'`       | the same as CRuby
+Riak       | `gem 'docker-api', '~> 1.21.1'; gem 'riak-client'` | the same as CRuby
+HBase      | N/A                 | gem 'hbase-jruby'
 
 
 ## Usage
@@ -91,8 +92,7 @@ end
 
 ### riak in code
 
-Mcrain::Riak uses [docker-riak](https://github.com/hectcastro/docker-riak).
-So set the path to `Mcrain.docker_riak_path` .
+Mcrain::Riak uses [hectcastro/docker-riak](https://github.com/hectcastro/docker-riak).
 
 ```ruby
 Mcrain::Riak.new.start do |s|
@@ -100,6 +100,35 @@ Mcrain::Riak.new.start do |s|
   obj = c.bucket("bucket1").get_or_new("foo")
   obj.data = data
   obj.store
+end
+```
+
+### hbase in code
+
+Mcrain::Hbase uses [nerdammer/hbase](https://hub.docker.com/r/nerdammer/hbase).
+
+add hostname to /etc/hosts befoe use it
+
+With docker toolbox
+
+```
+192.168.99.100 docker-host1
+```
+
+Without docker toolbox
+
+```
+127.0.0.1 docker-host1
+```
+
+
+```ruby
+Mcrain::Hbase.new.start do |s|
+  c = s.client # Riak::Client object
+  c.list
+  c[:my_table].create! :f
+  c[:my_table].put 100, 'f:a' => 1, 'f:b' => 'two', 'f:c' => 3.14
+  c[:my_table].get(100).double('f:c') #=> 3.14
 end
 ```
 
@@ -133,7 +162,6 @@ OK
 ### riak in terminal
 
 ```
-$ export DOCKER_RIAK_PATH=/path/to/docker-riak
 $ mcrain start riak
 To connect:
 require 'riak'
@@ -156,6 +184,45 @@ OK
 $ mcrain stop riak 5
 OK
 ```
+
+
+
+### hbase in terminal
+
+add hostname to /etc/hosts befoe use it
+
+With docker toolbox
+
+```
+192.168.99.100 docker-host1
+```
+
+Without docker toolbox
+
+```
+127.0.0.1 docker-host1
+```
+
+
+```
+$ mcrain start hbase
+(snip)
+To connect:
+$CLASSPATH << "/Users/akima/.mcrain/hbase/hbase-client-dep-1.0.jar"
+$LOAD_PATH << "hbase-jruby/lib"
+require 'hbase-jruby'
+client = HBase.new(*[{"hbase.zookeeper.quorum"=>"192.168.99.100", "hbase.zookeeper.property.clientPort"=>54489, "hbase.master.port"=>60000, "hbase.master.info.port"=>54490, "hbase.regionserver.port"=>60020, "hbase.regionserver.info.port"=>54491}])
+OK
+
+$ mcrain stop riak
+(snip)
+86a8dd6c13cd2c346fe9111e16f97265cb4fdb67cc67873c495622a28f0c1062
+OK
+```
+
+use irb or something in JRuby.
+
+
 
 ## Mcrain.before_setup
 

--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Or install it yourself as:
 middleware | client gem (CRuby)  | client gem (JRuby)
 -----------|---------------------|------------------
 MySQL      | `gem 'mysql2'`      | N/A
-Redis      | `gem 'redis'`       | the same as CRuby
-RabbitMQ   | `gem 'rabbitmq_http_api_client', '>= 1.6.0'`       | the same as CRuby
-Riak       | `gem 'docker-api', '~> 1.21.1'; gem 'riak-client'` | the same as CRuby
-HBase      | N/A                 | gem 'hbase-jruby'
+Redis      | `gem 'redis'`       | (the same as CRuby)
+RabbitMQ   | `gem 'rabbitmq_http_api_client', '>= 1.6.0'`       | (the same as CRuby)
+Riak       | `gem 'docker-api', '~> 1.21.1'; gem 'riak-client'` | (the same as CRuby)
+HBase      | N/A                 | `gem 'hbase-jruby'`
 
 
 ## Usage
@@ -107,24 +107,17 @@ end
 
 Mcrain::Hbase uses [nerdammer/hbase](https://hub.docker.com/r/nerdammer/hbase).
 
-add hostname to /etc/hosts befoe use it
+Add a line like this to `/etc/hosts`
 
-With docker toolbox
-
-```
-192.168.99.100 docker-host1
-```
-
-Without docker toolbox
-
-```
-127.0.0.1 docker-host1
-```
+|      |       |
+|------|-------|
+| With docker toolbox    | `192.168.99.100 docker-host1` |
+| Without docker toolbox | `127.0.0.1 docker-host1` |
 
 
 ```ruby
 Mcrain::Hbase.new.start do |s|
-  c = s.client # Riak::Client object
+  c = s.client # HBase object defined by hbase-jruby
   c.list
   c[:my_table].create! :f
   c[:my_table].put 100, 'f:a' => 1, 'f:b' => 'two', 'f:c' => 3.14
@@ -189,19 +182,14 @@ OK
 
 ### hbase in terminal
 
-add hostname to /etc/hosts befoe use it
+add hostname to `/etc/hosts` befoe use it
 
-With docker toolbox
+Add a line like this to /etc/hosts
 
-```
-192.168.99.100 docker-host1
-```
-
-Without docker toolbox
-
-```
-127.0.0.1 docker-host1
-```
+|      |       |
+|------|-------|
+| With docker toolbox    | `192.168.99.100 docker-host1` |
+| Without docker toolbox | `127.0.0.1 docker-host1` |
 
 
 ```

--- a/exe/mcrain
+++ b/exe/mcrain
@@ -24,7 +24,7 @@ MESSAGE
   exit(1)
 end
 
-unless args.include?("-v") || args.include?("--verbose")
+unless verbose
   require 'logger'
   Mcrain.logger = Logger.new("/dev/null")
 end
@@ -46,8 +46,8 @@ begin
       exit(1)
     else
       server = Mcrain.class_for(service.to_sym).new(options)
-      container = server.start
-      open(cid_filepath, "w"){|f| f.puts(container.id)}
+      server.start
+      open(cid_filepath, "w"){|f| f.puts(server.container.id)}
       puts "To connect:\n#{server.client_script}"
     end
   when "stop" then

--- a/exe/mcrain
+++ b/exe/mcrain
@@ -48,7 +48,7 @@ begin
       server = Mcrain.class_for(service.to_sym).new(options)
       container = server.start
       open(cid_filepath, "w"){|f| f.puts(container.id)}
-      puts "To connect:\nrequire '#{server.client_require}'\nclient = #{server.client_script}"
+      puts "To connect:\n#{server.client_script}"
     end
   when "stop" then
     if File.readable?(cid_filepath)

--- a/lib/mcrain.rb
+++ b/lib/mcrain.rb
@@ -36,6 +36,7 @@ module Mcrain
       redis: "redis:2.8.19",
       rabbitmq: "rabbitmq:3.4.4-management",
       riak: "hectcastro/riak",
+      hbase: "nerdammer/hbase:latest",
     }.freeze
 
     def images
@@ -64,6 +65,11 @@ module Mcrain
     end
 
     attr_accessor :before_setup
+
+    attr_writer :home_dir
+    def home_dir
+      @home_dir ||= (ENV['MCRAIN_HOME'] || File.join(ENV['HOME'], '.mcrain'))
+    end
   end
 
   autoload :Base, 'mcrain/base'

--- a/lib/mcrain.rb
+++ b/lib/mcrain.rb
@@ -75,9 +75,11 @@ module Mcrain
   autoload :Redis, 'mcrain/redis'
   autoload :Rabbitmq, 'mcrain/rabbitmq'
   autoload :Mysql, 'mcrain/mysql'
+  autoload :Hbase, 'mcrain/hbase'
 
   register :riak, "Mcrain::Riak"
   register :redis, "Mcrain::Redis"
   register :rabbitmq, "Mcrain::Rabbitmq"
   register :mysql, "Mcrain::Mysql"
+  register :hbase, "Mcrain::Hbase"
 end

--- a/lib/mcrain/base.rb
+++ b/lib/mcrain/base.rb
@@ -42,11 +42,13 @@ module Mcrain
     end
 
     def setup
+      logger.info("#{self.class.name}#setup STARTED")
       return false if Mcrain.before_setup && !Mcrain.before_setup.call(self)
       Timeout.timeout(30) do
         DockerMachine.setup_docker_options
         container.start!
       end
+      logger.info("#{self.class.name}#setup COMPLETED")
       return container
     end
 
@@ -72,6 +74,7 @@ module Mcrain
     # ポートはdockerがまずLISTENしておいて、その後コンテナ内のミドルウェアが起動するので、
     # 実際にそのAPIを叩いてみて例外が起きないことを確認します。
     def wait
+      logger.info("#{self.class.name}#wait STARTED")
       Timeout.timeout(30) do
         begin
           wait_for_ready
@@ -81,6 +84,7 @@ module Mcrain
           retry
         end
       end
+      logger.info("#{self.class.name}#wait COMPLETED")
     end
 
     def wait_for_ready

--- a/lib/mcrain/base.rb
+++ b/lib/mcrain/base.rb
@@ -101,5 +101,11 @@ module Mcrain
       container.remove unless ENV['MCRAIN_KEEP_CONTAINERS'] =~ /true|yes|on|1/i
     end
 
+    class << self
+      def work_dir
+        File.join(Mcrain.home_dir, server_name.to_s)
+      end
+    end
+
   end
 end

--- a/lib/mcrain/client_provider.rb
+++ b/lib/mcrain/client_provider.rb
@@ -23,9 +23,13 @@ module Mcrain
       raise NotImplementedError
     end
 
-    def client_script
+    def client_instantiation_script
       client
       "#{client_class.name}.new(*#{client_init_args.inspect})"
+    end
+
+    def client_script
+      "require '#{server.client_require}'\nclient = #{server.client_script}"
     end
 
   end

--- a/lib/mcrain/client_provider.rb
+++ b/lib/mcrain/client_provider.rb
@@ -29,7 +29,7 @@ module Mcrain
     end
 
     def client_script
-      "require '#{server.client_require}'\nclient = #{server.client_script}"
+      "require '#{client_require}'\nclient = #{client_instantiation_script}"
     end
 
   end

--- a/lib/mcrain/client_provider.rb
+++ b/lib/mcrain/client_provider.rb
@@ -8,6 +8,7 @@ module Mcrain
     def build_client
       require client_require
       yield if block_given?
+      logger.debug("#{self.class.name}#build_client call: #{client_instantiation_script}")
       client_class.new(*client_init_args)
     end
 
@@ -24,11 +25,11 @@ module Mcrain
     end
 
     def client_instantiation_script
-      client
       "#{client_class.name}.new(*#{client_init_args.inspect})"
     end
 
     def client_script
+      client
       "require '#{client_require}'\nclient = #{client_instantiation_script}"
     end
 

--- a/lib/mcrain/docker_machine.rb
+++ b/lib/mcrain/docker_machine.rb
@@ -12,11 +12,29 @@ require 'docker'
 module Mcrain
   module DockerMachine
 
+    DEFAULT_HOSTNAME = 'docker-host1'.freeze
+
     class << self
       attr_accessor :certs_dir
 
       def docker_machine_name
         ENV['DOCKER_MACHINE_NAME']
+      end
+
+      def docker_hostname
+        ENV['MCRAIN_DOCKER_HOSTNAME'] || DEFAULT_HOSTNAME
+      end
+
+      def docker_hostname!
+        name = docker_hostname
+        return name if valid_docker_hostname?
+        raise "hostname: #{name.inspect} is not valid. Plase set it with docker IP address to /etc/hosts or export MCRAIN_DOCKER_HOSTNAME=(valid-hostname) ."
+      end
+
+      def valid_docker_hostname?
+        return !!IPSocket.getaddress(docker_hostname)
+      rescue SocketError
+        return false
       end
     end
     self.certs_dir = File.expand_path('.docker/machine/certs', ENV["HOME"])

--- a/lib/mcrain/hbase.rb
+++ b/lib/mcrain/hbase.rb
@@ -96,7 +96,7 @@ module Mcrain
 
     def build_docker_options
       r = super
-      r["Hostname"] = "hbase"
+      r["Hostname"] = Mcrain::DockerMachine.docker_hostname!
       PORT_DEFS.each do |key, d|
         r['HostConfig']['PortBindings']["#{d[:default]}/tcp"] = [{ 'HostPort' => send(d[:method]).to_s }]
       end

--- a/lib/mcrain/hbase.rb
+++ b/lib/mcrain/hbase.rb
@@ -1,0 +1,75 @@
+require 'mcrain'
+
+# don't require 'redis' here in order to use mcrain without 'redis' gem
+# require 'redis'
+
+module Mcrain
+  class Hbase < Base
+    self.server_name = :hbase
+
+    self.port = 60000 # hbase.master.port # 60000
+
+    DEFAULT_CLIENT_DEP_URL = "https://github.com/junegunn/hbase-client-dep/releases/download/1.0.0/hbase-client-dep-1.0.jar"
+    attr_writer :client_dep_url
+    def client_dep_url
+      @client_dep_url ||= DEFAULT_CLIENT_DEP_URL
+    end
+
+    def client_require
+      'hbase-jruby'
+    end
+
+    def client_class
+      ::HBase
+    end
+
+    # https://blog.cloudera.com/blog/2013/07/guide-to-using-apache-hbase-ports/
+    PORT_DEFS = {
+      'hbase.master.port'            => {method: :port                  , default: 60000},
+      'hbase.master.info.port'       => {method: :master_info_port      , default: 60010},
+      'hbase.regionserver.port'      => {method: :regionserver_port     , default: 60020},
+      'hbase.regionserver.info.port' => {method: :regionserver_info_port, default: 60030},
+    }.freeze
+
+    PORT_DEFS.each do |key, d|
+      mname = d[:method]
+      next if instance_methods.include?(mname)
+      module_eval("def #{mname}; @#{mname} ||= find_portno; end", __FILE__, __LINE__)
+    end
+
+    def client_init_args
+      options = {'hbase.zookeeper.quorum' => host}
+      PORT_DEFS.each do |key, d|
+        options[key] = send(d[:method])
+      end
+      return [options]
+    end
+
+    def build_client
+      $CLASSPATH << "hbase-client-dep-1.0.jar" # where is this jar file?
+      $LOAD_PATH << 'hbase-jruby/lib'
+      super
+    end
+
+    def client_script
+      [
+        '$CLASSPATH << "hbase-client-dep-1.0.jar"',
+        '$LOAD_PATH << "hbase-jruby/lib"',
+        super,
+      ].join("\n")
+    end
+
+    def wait_for_ready
+      client.tables
+    end
+
+    def build_docker_options
+      r = super
+      PORT_DEFS.each do |key, d|
+        r['HostConfig']['PortBindings']["#{d[:default]}/tcp"] = [{ 'HostPort' => send(d[:method]).to_s }]
+      end
+      return r
+    end
+
+  end
+end

--- a/lib/mcrain/hbase.rb
+++ b/lib/mcrain/hbase.rb
@@ -50,15 +50,20 @@ module Mcrain
     end
 
     def download_jar
+      logger.debug("#{self.class.name}#download_jar STARTED")
       FileUtils.mkdir_p(File.dirname(client_dep_jar_path))
       LoggerPipe.run(Mcrain.logger, "curl -L -o #{client_dep_jar_path} #{client_dep_jar_url}")
+      logger.debug("#{self.class.name}#download_jar COMPLETED")
     end
 
     def build_client
+      logger.debug("#{self.class.name}#build_client STARTED")
       download_jar unless File.exist?(client_dep_jar_path)
       $CLASSPATH << client_dep_jar_path
       $LOAD_PATH << 'hbase-jruby/lib'
-      super
+      r = super
+      logger.debug("#{self.class.name}#build_client COMPLETED")
+      return r
     end
 
     def client_script

--- a/lib/mcrain/version.rb
+++ b/lib/mcrain/version.rb
@@ -1,3 +1,3 @@
 module Mcrain
-  VERSION = "0.6.0"
+  VERSION = "0.7.0"
 end

--- a/spec/mcrain/before_setup_spec.rb
+++ b/spec/mcrain/before_setup_spec.rb
@@ -4,7 +4,9 @@ describe Mcrain::Base do
   before{ @before_setup_backup = Mcrain.before_setup }
   after{ Mcrain.before_setup = @before_setup_backup }
 
-  [Mcrain::Mysql, Mcrain::Rabbitmq, Mcrain::Redis, Mcrain::Riak].each do |server_class|
+  classes = [Mcrain::Rabbitmq, Mcrain::Redis, Mcrain::Riak]
+  classes << Mcrain::Mysql unless defined? JRUBY_VERSION
+  classes.each do |server_class|
     context server_class do
       it "starts with before_setup which returns true" do
         called = []

--- a/spec/mcrain/hbase_spec.rb
+++ b/spec/mcrain/hbase_spec.rb
@@ -1,0 +1,22 @@
+# coding: utf-8
+require 'spec_helper'
+
+require 'tmpdir'
+
+describe Mcrain::Hbase, skip_on_ruby: true do
+
+  context ".start" do
+    it do
+      first = nil
+      Mcrain::Hbase.new.start do |s|
+        hbase = s.client
+        hbase.list
+        hbase[:my_table].create! :f
+        hbase[:my_table].put 100, 'f:a' => 1, 'f:b' => 'two', 'f:c' => 3.14
+        expect(hbase[:my_table].get(100).double('f:c')).to eq 3.14
+      end
+    end
+
+  end
+
+end

--- a/spec/mcrain/mysql_spec.rb
+++ b/spec/mcrain/mysql_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 require 'tmpdir'
 
-describe Mcrain::Mysql do
+describe Mcrain::Mysql, skip_on_jruby: true do
 
   context ".start" do
     it "ping" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,3 +32,8 @@ if ENV['CIRCLECI']
   end
 end
 
+RSpec.configure do |config|
+  if defined? JRUBY_VERSION
+    config.filter_run_excluding skip_on_jruby: true
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,5 +35,7 @@ end
 RSpec.configure do |config|
   if defined? JRUBY_VERSION
     config.filter_run_excluding skip_on_jruby: true
+  else
+    config.filter_run_excluding skip_on_ruby: true
   end
 end


### PR DESCRIPTION
Enable to setup [HBase container](https://hub.docker.com/r/nerdammer/hbase/) with JRuby.

Set hostname `docker-host1` to `/etc/hosts` before you use Mcrain::Hbase.
https://github.com/groovenauts/mcrain/blob/2e4469d2e7c027e65f5583d05e7ad597ff15f28f/README.md#hbase-in-code
## Caution

Don't start Mcrain::Hbase in parallel because we can't launch 2 containers of `nerdammer/hbase` which works with ZooKeeper. ZK keeps the connection config to HBase master in their network, but we can't get the connection config for outside of their network from ZK. So `nerdammer/hbase` uses static port 60000 as hbase.master.port and 60020 as hbase.regionserver.port.
## reviewers
- [x] @nagachika 
- [x] @minimum2scp 
