### PR TITLE
Mcrain.wait_port_opened should rescue Errno::EHOSTUNREACH.

### DIFF
--- a/lib/mcrain.rb
+++ b/lib/mcrain.rb
@@ -57,7 +57,7 @@ module Mcrain
           s = TCPSocket.open(host, port)
           s.close
           return true
-        rescue Errno::ECONNREFUSED
+        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
           sleep(interval)
           retry
         end

--- a/lib/mcrain/version.rb
+++ b/lib/mcrain/version.rb
@@ -1,3 +1,3 @@
 module Mcrain
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end


### PR DESCRIPTION
When container was created but network routing is not setup yet, connect to container could raise Errno::EHOSTUNREACH instead of Errno::ECONNREFUSED.
- [x] @akm 
- [x] @minimum2scp 
