### PR TITLE
pass v=1 option at remove container to get rid of volumes leak.

### DIFF
--- a/lib/mcrain/base.rb
+++ b/lib/mcrain/base.rb
@@ -102,7 +102,7 @@ module Mcrain
       rescue => e
         container.kill!
       end
-      container.remove unless ENV['MCRAIN_KEEP_CONTAINERS'] =~ /true|yes|on|1/i
+      container.remove(v: "1") unless ENV['MCRAIN_KEEP_CONTAINERS'] =~ /true|yes|on|1/i
     end
 
     class << self


### PR DESCRIPTION
The all images mcrain support have volumes entries and when containers are removed dangling volumes are leaks. I should remove dangling volumes by `docker volume rm $(docker volume ls -qf dangling=true)` periodically. 
To get rid of this annoying issue, pass v=1 option for container remove operation.
See https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#remove-a-container
- [x] @akm 
- [x] @minimum2scp 
