### PR TITLE
Recent hectcastro/riak:latest image needs DOCKER_RIAK_STRONG_CONSISTENCY

### DIFF
--- a/lib/mcrain/riak.rb
+++ b/lib/mcrain/riak.rb
@@ -10,17 +10,21 @@ module Mcrain
     self.server_name = :riak
 
     attr_accessor :automatic_clustering
-    attr_writer :cluster_size, :backend
+    attr_writer :cluster_size, :backend, :strong_consistency
     def cluster_size
       @cluster_size ||= 1
     end
     def backend
       @backend ||= "bitcask" # "leveldb"
     end
+    def strong_consistency
+      @strong_consistency ||= "off"
+    end
 
     # docker run -e "DOCKER_RIAK_CLUSTER_SIZE=${DOCKER_RIAK_CLUSTER_SIZE}" \
     #            -e "DOCKER_RIAK_AUTOMATIC_CLUSTERING=${DOCKER_RIAK_AUTOMATIC_CLUSTERING}" \
     #            -e "DOCKER_RIAK_BACKEND=${DOCKER_RIAK_BACKEND}" \
+    #            -e "DOCKER_RIAK_STRONG_CONSISTENCY=${DOCKER_RIAK_STRONG_CONSISTENCY} \
     #            -p $publish_http_port \
     #            -p $publish_pb_port \
     #            --link "riak01:seed" \
@@ -51,6 +55,7 @@ module Mcrain
         envs << "DOCKER_RIAK_CLUSTER_SIZE=#{owner.cluster_size}"
         envs << "DOCKER_RIAK_AUTOMATIC_CLUSTERING=#{owner.automatic_clustering ? 1 : 0}"
         envs << "DOCKER_RIAK_BACKEND=#{owner.backend}"
+        envs << "DOCKER_RIAK_STRONG_CONSISTENCY=#{owner.strong_consistency}"
         r['Env'] = envs unless envs.empty?
         if primary_node
           r['HostConfig']['Links'] = ["#{primary_node.name}:seed"]

--- a/lib/mcrain/version.rb
+++ b/lib/mcrain/version.rb
@@ -1,3 +1,3 @@
 module Mcrain
-  VERSION = "0.7.1"
+  VERSION = "0.7.2"
 end


### PR DESCRIPTION
When launch hectcastro/riak:latest image without `DOCKER_RIAK_STRONG_CONSISTENCY` (added in https://github.com/hectcastro/docker-riak/pull/47),
the riak process restarts every 2 seconds, because `strong_consistency` parameter in /etc/riak/riak.conf is broken.

```
% docker run --name riak01 -d -e DOCKER_RIAK_CLUSTER_SIZE=1 -e DOCKER_RIAK_AUTOMATIC_CLUSTERING=0 -e DOCKER_RIAK_BACKEND=leveldb hectcastro/riak:latest                        
fc2d8832db70d912128f5c1fc461bb5ee685ad4800996d042f19a250f5563b11

% docker logs -f riak01
No SSH host key available. Generating one...
Creating SSH2 RSA key; this may take some time ...
Creating SSH2 DSA key; this may take some time ...
Creating SSH2 ECDSA key; this may take some time ...
Creating SSH2 ED25519 key; this may take some time ...
invoke-rc.d: policy-rc.d denied execution of restart.
run_erl:615 [103] Thu Apr 21 02:26:08 2016
Erlang closed the connection.
run_erl:615 [213] Thu Apr 21 02:26:09 2016
Erlang closed the connection.
run_erl:615 [321] Thu Apr 21 02:26:11 2016
Erlang closed the connection.
run_erl:615 [424] Thu Apr 21 02:26:12 2016
Erlang closed the connection.
run_erl:615 [527] Thu Apr 21 02:26:14 2016
Erlang closed the connection.
run_erl:615 [630] Thu Apr 21 02:26:16 2016
Erlang closed the connection.
^C

% docker exec riak01 grep strong_consistency /etc/riak/riak.conf
strong_consistency = 
```

So mcrain should set `DOCKER_RIAK_STRONG_CONSISTENCY` to launch hectcastro/riak:latest image.
## Reviewers:
- [x] @nagachika 
- [x] @akm 
