### PR TITLE
support activesupport 5 and later

### DIFF
--- a/lib/mcrain/version.rb
+++ b/lib/mcrain/version.rb
@@ -1,3 +1,3 @@
 module Mcrain
-  VERSION = "0.7.2"
+  VERSION = "0.7.3"
 end

--- a/mcrain.gemspec
+++ b/mcrain.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "logger_pipe", "~> 0.3.1"
   spec.add_runtime_dependency "net-scp", "~> 1.2.1"
-  spec.add_runtime_dependency "activesupport", ">= 3.0", "< 5.0"
+  spec.add_runtime_dependency "activesupport", ">= 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
I'd like to allow mcrain used with activesupport 5 and later.
