### PR TITLE
Fixed typo

### DIFF
--- a/exe/mcrain
+++ b/exe/mcrain
@@ -92,7 +92,7 @@ begin
 
 rescue => e
   $stderr.puts "\e[31m[#{e.class}] #{e.message}\e[0m"
-  $stderr.puts e.backtrace.join("\n  ") if verbose
+  $stderr.puts e.backtrace.join("\n  ") if opts[:verbose]
   exit(1)
 else
   $stderr.puts "\e[32mOK\e[0m"

--- a/lib/mcrain/version.rb
+++ b/lib/mcrain/version.rb
@@ -1,3 +1,3 @@
 module Mcrain
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end


### PR DESCRIPTION
When docker image cannot be pulled, the error handling did not work correctly because of typo.

```
+ bundle exec mcrain pull rabbitmq
[LoggerPipe::Failure] FAILURE: docker pull rabbitmq:3.5.7-management 2>/tmp/logger_pipe.stderr.log20181030-5441-1l5soh2
/opt/bundler/ruby/2.4.0/gems/mcrain-0.8.0/exe/mcrain:95:in `rescue in <top (required)>': undefined local variable or method `verbose' for main:Object (NameError)
	from /opt/bundler/ruby/2.4.0/gems/mcrain-0.8.0/exe/mcrain:52:in `<top (required)>'
	from /opt/bundler/ruby/2.4.0/bin/mcrain:23:in `load'
	from /opt/bundler/ruby/2.4.0/bin/mcrain:23:in `<main>'
script returned exit code 1
```

