### PR TITLE
Extend timeout in wait method

### DIFF
--- a/lib/mcrain/base.rb
+++ b/lib/mcrain/base.rb
@@ -75,7 +75,7 @@ module Mcrain
     # 実際にそのAPIを叩いてみて例外が起きないことを確認します。
     def wait
       logger.info("#{self.class.name}#wait STARTED")
-      Timeout.timeout(30) do
+      Timeout.timeout(60) do
         begin
           wait_for_ready
         rescue => e

--- a/lib/mcrain/version.rb
+++ b/lib/mcrain/version.rb
@@ -1,3 +1,3 @@
 module Mcrain
-  VERSION = "0.8.1"
+  VERSION = "0.8.2"
 end


### PR DESCRIPTION
When CI server is in too heavy load,
starting multiple `mysql:5.7` containers takes longer time than `mysql:5.5` /  `mysql:5.6`, 
and sometimes it timed out...

```
  1) XXX::Database with mcrain #check_xxx! don't call block unnecessarily
     Failure/Error:
       mysql_server.start do |s|
         @server = s
         example.run
       end

     Timeout::Error:
       execution expired
     # /opt/bundler/xxx/ruby/2.4.0/gems/activesupport-5.0.6/lib/active_support/logger.rb:87:in `add'
     # /opt/bundler/xxx/ruby/2.4.0/gems/mcrain-0.8.1/lib/mcrain/client_provider.rb:11:in `build_client'
     # /opt/bundler/xxx/ruby/2.4.0/gems/mcrain-0.8.1/lib/mcrain/client_provider.rb:5:in `client'
     # /opt/bundler/xxx/ruby/2.4.0/gems/mcrain-0.8.1/lib/mcrain/mysql.rb:32:in `wait_for_ready'
     # /opt/bundler/xxx/ruby/2.4.0/gems/mcrain-0.8.1/lib/mcrain/base.rb:80:in `block in wait'
     # /opt/bundler/xxx/ruby/2.4.0/gems/mcrain-0.8.1/lib/mcrain/base.rb:78:in `wait'
     # /opt/bundler/xxx/ruby/2.4.0/gems/mcrain-0.8.1/lib/mcrain/base.rb:58:in `start_callback'
     # /opt/bundler/xxx/ruby/2.4.0/gems/mcrain-0.8.1/lib/mcrain/base.rb:37:in `start'
     # ./spec/models/xxx/database/check_xxx_spec.rb:35:in `block (3 levels) in <top (required)>'
```

This may be caused by creating SSL certificates during `mysql:5.7` container startup.
https://github.com/docker-library/mysql/blob/9e0ea0bed1e0740a733d224b893b7b8fcd692635/5.7/docker-entrypoint.sh#L112-L117

So I want to extend timeout threashold in `wait` method.
