### PR TITLE
Removed CircleCI build status badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Mcrain
 
-[![Circle CI](https://circleci.com/gh/groovenauts/mcrain/tree/master.svg?style=svg)](https://circleci.com/gh/groovenauts/mcrain/tree/master)
-
 Mcrain helps you to use docker container in test cases.
 It supports redis, rabbitmq and riak (stand alone node or clustering) currently.
 


### PR DESCRIPTION
Already disabled (unfollowed) CircleCI in #32.